### PR TITLE
Fix links to broken/obsolete proposals

### DIFF
--- a/proposals/reference-types/Overview.md
+++ b/proposals/reference-types/Overview.md
@@ -18,8 +18,8 @@ by repurposing tables as a general memory for opaque data types
 * Set the stage for later additions:
 
   - Typed function references (see [below](#typed-function-references))
-  - Exception references (see the [exception handling proposal](https://github.com/WebAssembly/exception-handling/blob/master/proposals/Exceptions.md) and [here](https://github.com/WebAssembly/host-bindings/issues/10))
-  - A smoother transition path to GC (see the [GC proposal](https://github.com/WebAssembly/gc/blob/master/proposals/GC.md))
+  - Exception references (see the [exception handling proposal](https://github.com/WebAssembly/exception-handling/blob/master/proposals/Level-1.md) and [here](https://github.com/WebAssembly/host-bindings/issues/10))
+  - A smoother transition path to GC (see the [GC proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md))
 
 Get the most important parts soon!
 


### PR DESCRIPTION
The Exceptions link in Overview points to the outdated/obsolete version of the proposal, while the GC proposal link was broken. Updated both to the current versions.