### PR TITLE
Increase the table count limit to 100,000

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1112,7 +1112,7 @@ In practice, an implementation may run out of resources for valid modules below 
 <li>The maximum number of globals defined in a module is 1000000.</li>
 <li>The maximum number of data segments defined in a module is 100000.</li>
 
-<li>The maximum number of tables, including declared or imported tables, is 1.</li>
+<li>The maximum number of tables, including declared or imported tables, is 100000.</li>
 <li>The maximum size of a table is 10000000.</li>
 <li>The maximum number of table entries in any table initialization is 10000000.</li>
 <li>The maximum number of memories, including declared or imported memories, is 1.</li>

--- a/test/js-api/limits.any.js
+++ b/test/js-api/limits.any.js
@@ -17,7 +17,7 @@ const kJSEmbeddingMaxFunctionParams = 1000;
 const kJSEmbeddingMaxFunctionReturns = 1;
 const kJSEmbeddingMaxTableSize = 10000000;
 const kJSEmbeddingMaxElementSegments = 10000000;
-const kJSEmbeddingMaxTables = 1;
+const kJSEmbeddingMaxTables = 100000;
 const kJSEmbeddingMaxMemories = 1;
 
 // This function runs the {gen} function with the values {min}, {limit}, and


### PR DESCRIPTION
With multi-table we need a common implementation limit for the max number of tables.  Firefox uses 100K as the limit currently so that's what I'm proposing here, but it's just a strawman value - please discuss.