### PR TITLE
[spec] Correctly account for subtyping in global/table instances

### DIFF
--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -280,15 +280,13 @@ Functions
 :math:`\F{func\_type}(\store, \funcaddr) : \functype`
 .....................................................
 
-1. Assert: the :ref:`external value <syntax-externval>` :math:`\EVFUNC~\funcaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETFUNC~\functype`.
+1. Return :math:`S.\SFUNCS[a].\FITYPE`.
 
-2. Return :math:`\functype`.
-
-3. Post-condition: :math:`\functype` is :ref:`valid <valid-functype>`.
+2. Post-condition: the returned :ref:`function type <syntax-functype>` is :ref:`valid <valid-functype>`.
 
 .. math::
    \begin{array}{lclll}
-   \F{func\_type}(S, a) &=& \X{ft} && (\iff S \vdashexternval \EVFUNC~a : \ETFUNC~\X{ft}) \\
+   \F{func\_type}(S, a) &=& S.\SFUNCS[a].\FITYPE \\
    \end{array}
 
 
@@ -345,15 +343,13 @@ Tables
 :math:`\F{table\_type}(\store, \tableaddr) : \tabletype`
 ........................................................
 
-1. Assert: the :ref:`external value <syntax-externval>` :math:`\EVTABLE~\tableaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETTABLE~\tabletype`.
+1. Return :math:`S.\STABLES[a].\TITYPE`.
 
-2. Return :math:`\tabletype`.
-
-3. Post-condition: :math:`\tabletype` is :math:`valid <valid-tabletype>`.
+2. Post-condition: the returned :ref:`table type <syntax-tabletype>` is :math:`valid <valid-tabletype>`.
 
 .. math::
    \begin{array}{lclll}
-   \F{table\_type}(S, a) &=& \X{tt} && (\iff S \vdashexternval \EVTABLE~a : \ETTABLE~\X{tt}) \\
+   \F{table\_type}(S, a) &=& S.\STABLES[a].\TITYPE \\
    \end{array}
 
 
@@ -459,15 +455,13 @@ Memories
 :math:`\F{mem\_type}(\store, \memaddr) : \memtype`
 ..................................................
 
-1. Assert: the :ref:`external value <syntax-externval>` :math:`\EVMEM~\memaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETMEM~\memtype`.
+1. Return :math:`S.\SMEMS[a].\MITYPE`.
 
-2. Return :math:`\memtype`.
-
-3. Post-condition: :math:`\memtype` is :math:`valid <valid-memtype>`.
+2. Post-condition: the returned :ref:`memory type <syntax-memtype>` is :math:`valid <valid-memtype>`.
 
 .. math::
    \begin{array}{lclll}
-   \F{mem\_type}(S, a) &=& \X{mt} && (\iff S \vdashexternval \EVMEM~a : \ETMEM~\X{mt}) \\
+   \F{mem\_type}(S, a) &=& S.\SMEMS[a].\MITYPE \\
    \end{array}
 
 
@@ -574,15 +568,13 @@ Globals
 :math:`\F{global\_type}(\store, \globaladdr) : \globaltype`
 ...........................................................
 
-1. Assert: the :ref:`external value <syntax-externval>` :math:`\EVGLOBAL~\globaladdr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETGLOBAL~\globaltype`.
+1. Return :math:`S.\SGLOBALS[a].\GITYPE`.
 
-2. Return :math:`\globaltype`.
-
-3. Post-condition: :math:`\globaltype` is :math:`valid <valid-globaltype>`.
+2. Post-condition: the returned :ref:`global type <syntax-globaltype>` is :math:`valid <valid-globaltype>`.
 
 .. math::
    \begin{array}{lclll}
-   \F{global\_type}(S, a) &=& \X{gt} && (\iff S \vdashexternval \EVGLOBAL~a : \ETGLOBAL~\X{gt}) \\
+   \F{global\_type}(S, a) &=& S.\SGLOBALS[a].\GITYPE \\
    \end{array}
 
 

--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -608,15 +608,17 @@ Globals
 
 1. Let :math:`\X{gi}` be the :ref:`global instance <syntax-globalinst>` :math:`\store.\SGLOBALS[\globaladdr]`.
 
-2. If :math:`\X{gi}.\GIMUT` is not :math:`\MVAR`, then return :math:`\ERROR`.
+2. Let :math:`\mut~t` be the structure of the :ref:`global type <syntax-globaltype>` :math:`\X{gi}.\GITYPE`.
 
-3. Replace :math:`\X{gi}.\GIVALUE` with the :ref:`value <syntax-val>` :math:`\val`.
+3. If :math:`\mut` is not :math:`\MVAR`, then return :math:`\ERROR`.
 
-4. Return the updated store.
+4. Replace :math:`\X{gi}.\GIVALUE` with the :ref:`value <syntax-val>` :math:`\val`.
+
+5. Return the updated store.
 
 .. math::
    ~ \\
    \begin{array}{lclll}
-   \F{global\_write}(S, a, v) &=& S' && (\iff S.\SGLOBALS[a].\GIMUT = \MVAR \wedge S' = S \with \SGLOBALS[a].\GIVALUE = v) \\
+   \F{global\_write}(S, a, v) &=& S' && (\iff S.\SGLOBALS[a].\GITYPE = \MVAR~t \wedge S' = S \with \SGLOBALS[a].\GIVALUE = v) \\
    \F{global\_write}(S, a, v) &=& \ERROR && (\otherwise) \\
    \end{array}

--- a/document/core/appendix/index-rules.rst
+++ b/document/core/appendix/index-rules.rst
@@ -78,7 +78,10 @@ Matching
 ===============================================  ===============================================================================
 Construct                                        Judgement
 ===============================================  ===============================================================================
+:ref:`Number type <match-numtype>`               :math:`\vdashnumtypematch \numtype_1 \matchesvaltype \numtype_2`
+:ref:`Reference type <match-reftype>`            :math:`\vdashreftypematch \reftype_1 \matchesvaltype \reftype_2`
 :ref:`Value type <match-valtype>`                :math:`\vdashvaltypematch \valtype_1 \matchesvaltype \valtype_2`
+:ref:`Result type <match-resulttype>`            :math:`\vdashresulttypematch [t_1^?] \matchesresulttype [t_2^?]`
 :ref:`External type <match-externtype>`          :math:`\vdashexterntypematch \externtype_1 \matchesexterntype \externtype_2`
 :ref:`Limits <match-limits>`                     :math:`\vdashlimitsmatch \limits_1 \matcheslimits \limits_2`
 ===============================================  ===============================================================================

--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -196,10 +196,12 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 .. index:: table type, table instance, limits, function address
 .. _valid-tableinst:
 
-:ref:`Table Instances <syntax-tableinst>` :math:`\{ \TITYPE~(\{\LMIN~n', \LMAX~m^?\}~t), \TIELEM~\reff^n \}`
-............................................................................................................
+:ref:`Table Instances <syntax-tableinst>` :math:`\{ \TITYPE~(\limits~t), \TIELEM~\reff^\ast \}`
+...............................................................................................
 
-* The :ref:`table type <syntax-tabletype>` :math:`\{\LMIN~n', \LMAX~m^?\}~t` must be :ref:`valid <valid-tabletype>`.
+* The :ref:`table type <syntax-tabletype>` :math:`\limits~t` must be :ref:`valid <valid-tabletype>`.
+
+* The length of :math:`\reff^\ast` must equal :math:`\limits.\LMIN`.
 
 * For each :ref:`reference <syntax-ref>` :math:`\reff_i` in the table elements :math:`\reff^n`:
 
@@ -207,35 +209,41 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 
   * The :ref:`reference type <syntax-reftype>` :math:`t'_i` must :ref:`match <match-reftype>` the :ref:`reference type <syntax-reftype>` :math:`t`.
 
-* Then the table instance is valid with :ref:`table type <syntax-tabletype>` :math:`\{\LMIN~n, \LMAX~m^?\}~t`.
+* Then the table instance is valid with :ref:`table type <syntax-tabletype>` :math:`\limits~t`.
 
 .. math::
    \frac{
-     \vdashtabletype \{\LMIN~n', \LMAX~m^?\}~t \ok
+     \vdashtabletype \limits~t \ok
+     \qquad
+     n = \limits.\LMIN
      \qquad
      (S \vdash \reff : t')^n
      \qquad
      (\vdashreftypematch t' \matchesvaltype t)^n
    }{
-     S \vdashtableinst \{ \TITYPE~(\{\LMIN~n', \LMAX~m^?\}~t), \TIELEM~\reff^n \} : \{\LMIN~n, \LMAX~m^?\}~t
+     S \vdashtableinst \{ \TITYPE~(\limits~t), \TIELEM~\reff^n \} : \limits~t
    }
 
 
 .. index:: memory type, memory instance, limits, byte
 .. _valid-meminst:
 
-:ref:`Memory Instances <syntax-meminst>` :math:`\{ \MITYPE~\{\LMIN~n', \LMAX~m^?\}, \MIDATA~b^n \}`
-...................................................................................................
+:ref:`Memory Instances <syntax-meminst>` :math:`\{ \MITYPE~\limits, \MIDATA~b^\ast \}`
+......................................................................................
 
 * The :ref:`memory type <syntax-memtype>` :math:`\{\LMIN~n, \LMAX~m^?\}` must be :ref:`valid <valid-memtype>`.
 
-* Then the memory instance is valid with :ref:`memory type <syntax-memtype>` :math:`\{\LMIN~n, \LMAX~m^?\}`.
+* The length of :math:`b^\ast` must equal :math:`\limits.\LMIN` multiplied by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`.
+
+* Then the memory instance is valid with :ref:`memory type <syntax-memtype>` :math:`\limits`.
 
 .. math::
    \frac{
-     \vdashmemtype \{\LMIN~n, \LMAX~m^?\} \ok
+     \vdashmemtype \limits \ok
+     \qquad
+     n = \limits.\LMIN \cdot 64\,\F{Ki}
    }{
-     S \vdashmeminst \{ \MITYPE~\{\LMIN~n', \LMAX~m^?\}, \MIDATA~b^n \} : \{\LMIN~n, \LMAX~m^?\}
+     S \vdashmeminst \{ \MITYPE~\limits, \MIDATA~b^n \} : \limits
    }
 
 
@@ -521,7 +529,7 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
 :math:`\INITELEM~\tableaddr~o~x^n`
 ..................................
 
-* The :ref:`external table value <syntax-externval>` :math:`\EVTABLE~\tableaddr` must be :ref:`valid <valid-externval-table>` with some :ref:`external table type <syntax-externtype>` :math:`\ETTABLE~\limits~\FUNCREF`.
+* The :ref:`external table value <syntax-externval>` :math:`\EVTABLE~\tableaddr` must be :ref:`valid <valid-externval-table>` with some :ref:`external table type <syntax-externtype>` :math:`\ETTABLE~(\limits~\FUNCREF)`.
 
 * The index :math:`o + n` must be smaller than or equal to :math:`\limits.\LMIN`.
 

--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -196,59 +196,72 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 .. index:: table type, table instance, limits, function address
 .. _valid-tableinst:
 
-:ref:`Table Instances <syntax-tableinst>` :math:`\{ \TIELEM~(\X{fa}^?)^n, \TIMAX~m^? \}`
-..............................................................................................
+:ref:`Table Instances <syntax-tableinst>` :math:`\{ \TITYPE~(\{\LMIN~n', \LMAX~m^?\}~t), \TIELEM~\reff^n \}`
+............................................................................................................
 
-* For each optional :ref:`function address <syntax-funcaddr>` :math:`\X{fa}^?_i` in the table elements :math:`(\X{fa}^?)^n`:
+* The :ref:`table type <syntax-tabletype>` :math:`\{\LMIN~n', \LMAX~m^?\}~t` must be :ref:`valid <valid-tabletype>`.
 
-  * Either :math:`\X{fa}^?_i` is empty.
+* For each :ref:`reference <syntax-ref>` :math:`\reff_i` in the table elements :math:`\reff^n`:
 
-  * Or the :ref:`external value <syntax-externval>` :math:`\EVFUNC~\X{fa}` must be :ref:`valid <valid-externval-func>` with some :ref:`external type <syntax-externtype>` :math:`\ETFUNC~\X{ft}`.
+  * The :ref:`reference <syntax-ref>` :math:`\reff_i` must be :ref:`valid <valid-ref>` with some :ref:`reference type <syntax-reftype>` :math:`t'_i`.
 
-* The :ref:`limits <syntax-limits>` :math:`\{\LMIN~n, \LMAX~m^?\}` must be :ref:`valid <valid-limits>`.
+  * The :ref:`reference type <syntax-reftype>` :math:`t'_i` must :ref:`match <match-reftype>` the :ref:`reference type <syntax-reftype>` :math:`t`.
 
-* Then the table instance is valid with :ref:`table type <syntax-tabletype>` :math:`\{\LMIN~n, \LMAX~m^?\}~\FUNCREF`.
+* Then the table instance is valid with :ref:`table type <syntax-tabletype>` :math:`\{\LMIN~n, \LMAX~m^?\}~t`.
 
 .. math::
    \frac{
-     ((S \vdash \EVFUNC~\X{fa} : \ETFUNC~\functype)^?)^n
+     \vdashtabletype \{\LMIN~n', \LMAX~m^?\}~t \ok
      \qquad
-     \vdashlimits \{\LMIN~n, \LMAX~m^?\} \ok
+     (S \vdash \reff : t')^n
+     \qquad
+     (\vdashreftypematch t' \matchesvaltype t)^n
    }{
-     S \vdashtableinst \{ \TIELEM~(\X{fa}^?)^n, \TIMAX~m^? \} : \{\LMIN~n, \LMAX~m^?\}~\FUNCREF
+     S \vdashtableinst \{ \TITYPE~(\{\LMIN~n', \LMAX~m^?\}~t), \TIELEM~\reff^n \} : \{\LMIN~n, \LMAX~m^?\}~t
    }
 
 
 .. index:: memory type, memory instance, limits, byte
 .. _valid-meminst:
 
-:ref:`Memory Instances <syntax-meminst>` :math:`\{ \MIDATA~b^n, \MIMAX~m^? \}`
-..............................................................................
+:ref:`Memory Instances <syntax-meminst>` :math:`\{ \MITYPE~\{\LMIN~n', \LMAX~m^?\}, \MIDATA~b^n \}`
+...................................................................................................
 
-* The :ref:`limits <syntax-limits>` :math:`\{\LMIN~n, \LMAX~m^?\}` must be :ref:`valid <valid-limits>`.
+* The :ref:`memory type <syntax-memtype>` :math:`\{\LMIN~n, \LMAX~m^?\}` must be :ref:`valid <valid-memtype>`.
 
 * Then the memory instance is valid with :ref:`memory type <syntax-memtype>` :math:`\{\LMIN~n, \LMAX~m^?\}`.
 
 .. math::
    \frac{
-     \vdashlimits \{\LMIN~n, \LMAX~m^?\} \ok
+     \vdashmemtype \{\LMIN~n, \LMAX~m^?\} \ok
    }{
-     S \vdashmeminst \{ \MIDATA~b^n, \MIMAX~m^? \} : \{\LMIN~n, \LMAX~m^?\}
+     S \vdashmeminst \{ \MITYPE~\{\LMIN~n', \LMAX~m^?\}, \MIDATA~b^n \} : \{\LMIN~n, \LMAX~m^?\}
    }
 
 
 .. index:: global type, global instance, value, mutability
 .. _valid-globalinst:
 
-:ref:`Global Instances <syntax-globalinst>` :math:`\{ \GIVALUE~(t.\CONST~c), \GIMUT~\mut \}`
-............................................................................................
+:ref:`Global Instances <syntax-globalinst>` :math:`\{ \GITYPE~(\mut~t), \GIVALUE~\val \}`
+.........................................................................................
 
-* The global instance is valid with :ref:`global type <syntax-globaltype>` :math:`\mut~t`.
+* The :ref:`global type <syntax-globaltype>` :math:`\mut~t` must be :ref:`valid <valid-globaltype>`.
+
+* The :ref:`value <syntax-val>` :math:`\val` must be :ref:`valid <valid-val>` with some :ref:`value type <syntax-valtype>` :math:`t'`.
+
+* The :ref:`value type <syntax-valtype>` :math:`t'` must :ref:`match <match-valtype>` the :ref:`value type <syntax-valtype>` :math:`t`.
+
+* Then the global instance is valid with :ref:`global type <syntax-globaltype>` :math:`\mut~t`.
 
 .. math::
    \frac{
+     \vdashglobaltype \mut~t \ok
+     \qquad
+     S \vdashval \val : t'
+     \qquad
+     \vdashvaltypematch t' \matchesvaltype t
    }{
-     S \vdashglobalinst \{ \GIVALUE~(t.\CONST~c), \GIMUT~\mut \} : \mut~t
+     S \vdashglobalinst \{ \GITYPE~(\mut~t), \GIVALUE~\val \} : \mut~t
    }
 
 
@@ -676,15 +689,15 @@ a store state :math:`S'` extends state :math:`S`, written :math:`S \extendsto S'
 :ref:`Table Instance <syntax-tableinst>` :math:`\tableinst`
 ...........................................................
 
-* The length of :math:`\tableinst.\TIELEM` must not shrink.
+* The :ref:`table type <syntax-tabletype>` :math:`\tableinst.\TITYPE` must remain unchanged.
 
-* The value of :math:`\tableinst.\TIMAX` must remain unchanged.
+* The length of :math:`\tableinst.\TIELEM` must not shrink.
 
 .. math::
    \frac{
      n_1 \leq n_2
    }{
-     \vdashtableinstextends \{\TIELEM~(\X{fa}_1^?)^{n_1}, \TIMAX~m\} \extendsto \{\TIELEM~(\X{fa}_2^?)^{n_2}, \TIMAX~m\}
+     \vdashtableinstextends \{\TITYPE~\X{tt}, \TIELEM~(\X{fa}_1^?)^{n_1}\} \extendsto \{\TITYPE~\X{tt}, \TIELEM~(\X{fa}_2^?)^{n_2}\}
    }
 
 
@@ -694,15 +707,15 @@ a store state :math:`S'` extends state :math:`S`, written :math:`S \extendsto S'
 :ref:`Memory Instance <syntax-meminst>` :math:`\meminst`
 ........................................................
 
-* The length of :math:`\meminst.\MIDATA` must not shrink.
+* The :ref:`memory type <syntax-memtype>` :math:`\meminst.\MITYPE` must remain unchanged.
 
-* The value of :math:`\meminst.\MIMAX` must remain unchanged.
+* The length of :math:`\meminst.\MIDATA` must not shrink.
 
 .. math::
    \frac{
      n_1 \leq n_2
    }{
-     \vdashmeminstextends \{\MIDATA~b_1^{n_1}, \MIMAX~m\} \extendsto \{\MIDATA~b_2^{n_2}, \MIMAX~m\}
+     \vdashmeminstextends \{\MITYPE~\X{mt}, \MIDATA~b_1^{n_1}\} \extendsto \{\MITYPE~\X{mt}, \MIDATA~b_2^{n_2}\}
    }
 
 
@@ -712,17 +725,17 @@ a store state :math:`S'` extends state :math:`S`, written :math:`S \extendsto S'
 :ref:`Global Instance <syntax-globalinst>` :math:`\globalinst`
 ..............................................................
 
-* The :ref:`mutability <syntax-mut>` :math:`\globalinst.\GIMUT` must remain unchanged.
+* The :ref:`global type <syntax-globaltype>` :math:`\globalinst.\GITYPE` must remain unchanged.
 
-* The :ref:`value type <syntax-valtype>` of the :ref:`value <syntax-val>` :math:`\globalinst.\GIVALUE` must remain unchanged.
+* Let :math:`\mut~t` be the structure of :math:`\globalinst.\GITYPE`.
 
-* If :math:`\globalinst.\GIMUT` is |MCONST|, then the :ref:`value <syntax-val>` :math:`\globalinst.\GIVALUE` must remain unchanged.
+* If :math:`\mut` is |MCONST|, then the :ref:`value <syntax-val>` :math:`\globalinst.\GIVALUE` must remain unchanged.
 
 .. math::
    \frac{
-     \mut = \MVAR \vee c_1 = c_2
+     \mut = \MVAR \vee \val_1 = \val_2
    }{
-     \vdashglobalinstextends \{\GIVALUE~(t.\CONST~c_1), \GIMUT~\mut\} \extendsto \{\GIVALUE~(t.\CONST~c_2), \GIMUT~\mut\}
+     \vdashglobalinstextends \{\GITYPE~(\mut~t), \GIVALUE~\val_1\} \extendsto \{\GITYPE~(\mut~t), \GIVALUE~\val_2\}
    }
 
 

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -41,15 +41,15 @@ The following auxiliary typing rules specify this typing relation relative to a 
 :math:`\EVTABLE~a`
 ..................
 
-* The store entry :math:`S.\STABLES[a]` must be a :ref:`table instance <syntax-tableinst>` :math:`\{\TIELEM~(\X{fa}^?)^n, \TIMAX~m^?\}`.
+* The store entry :math:`S.\STABLES[a]` must be a :ref:`table instance <syntax-tableinst>` :math:`\{\TITYPE~(\{\LMIN~n', \LMAX~m^?\}~t), \TIELEM~\reff^n\}`.
 
-* Then :math:`\EVTABLE~a` is valid with :ref:`external type <syntax-externtype>` :math:`\ETTABLE~(\{\LMIN~n, \LMAX~m^?\}~\FUNCREF)`.
+* Then :math:`\EVTABLE~a` is valid with :ref:`external type <syntax-externtype>` :math:`\ETTABLE~(\{\LMIN~n, \LMAX~m^?\}~t)`.
 
 .. math::
    \frac{
-     S.\STABLES[a] = \{ \TIELEM~(\X{fa}^?)^n, \TIMAX~m^? \}
+     S.\STABLES[a] = \{ \TITYPE~(\{\LMIN~n', \LMAX~m^?\}~t), \TIELEM~\reff^n \}
    }{
-     S \vdashexternval \EVTABLE~a : \ETTABLE~(\{\LMIN~n, \LMAX~m^?\}~\FUNCREF)
+     S \vdashexternval \EVTABLE~a : \ETTABLE~(\{\LMIN~n, \LMAX~m^?\}~t)
    }
 
 
@@ -59,13 +59,13 @@ The following auxiliary typing rules specify this typing relation relative to a 
 :math:`\EVMEM~a`
 ................
 
-* The store entry :math:`S.\SMEMS[a]` must be a :ref:`memory instance <syntax-meminst>` :math:`\{\MIDATA~b^{n\cdot64\,\F{Ki}}, \MIMAX~m^?\}`, for some :math:`n`.
+* The store entry :math:`S.\SMEMS[a]` must be a :ref:`memory instance <syntax-meminst>` :math:`\{\MITYPE~\{\LMIN~n', \LMAX~m^?\}, \MIDATA~b^{n\cdot64\,\F{Ki}}\}`, for some :math:`n`.
 
 * Then :math:`\EVMEM~a` is valid with :ref:`external type <syntax-externtype>` :math:`\ETMEM~(\{\LMIN~n, \LMAX~m^?\})`.
 
 .. math::
    \frac{
-     S.\SMEMS[a] = \{ \MIDATA~b^{n\cdot64\,\F{Ki}}, \MIMAX~m^? \}
+     S.\SMEMS[a] = \{ \MITYPE~\{\LMIN~n', \LMAX~m^?\}, \MIDATA~b^{n\cdot64\,\F{Ki}} \}
    }{
      S \vdashexternval \EVMEM~a : \ETMEM~\{\LMIN~n, \LMAX~m^?\}
    }
@@ -77,13 +77,13 @@ The following auxiliary typing rules specify this typing relation relative to a 
 :math:`\EVGLOBAL~a`
 ...................
 
-* The store entry :math:`S.\SGLOBALS[a]` must be a :ref:`global instance <syntax-globalinst>` :math:`\{\GIVALUE~(t.\CONST~c), \GIMUT~\mut\}`.
+* The store entry :math:`S.\SGLOBALS[a]` must be a :ref:`global instance <syntax-globalinst>` :math:`\{\GITYPE~(\mut~t), \GIVALUE~\val\}`.
 
 * Then :math:`\EVGLOBAL~a` is valid with :ref:`external type <syntax-externtype>` :math:`\ETGLOBAL~(\mut~t)`.
 
 .. math::
    \frac{
-     S.\SGLOBALS[a] = \{ \GIVALUE~(t.\CONST~c), \GIMUT~\mut \}
+     S.\SGLOBALS[a] = \{ \GITYPE~(\mut~t), \GIVALUE~\val \}
    }{
      S \vdashexternval \EVGLOBAL~a : \ETGLOBAL~(\mut~t)
    }
@@ -99,6 +99,8 @@ For the purpose of checking argument :ref:`values <syntax-externval>` against th
 values are classified by :ref:`value types <syntax-valtype>`.
 The following auxiliary typing rules specify this typing relation relative to a :ref:`store <syntax-store>` :math:`S` in which possibly referenced addresses live.
 
+.. _valid-num:
+
 :ref:`Numeric Values <syntax-val>` :math:`t.\CONST~c`
 .....................................................
 
@@ -110,6 +112,7 @@ The following auxiliary typing rules specify this typing relation relative to a 
      S \vdashval t.\CONST~c : t
    }
 
+.. _valid-ref:
 
 :ref:`Null References <syntax-ref>` :math:`\REFNULL`
 ....................................................
@@ -359,13 +362,13 @@ New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tablei
 :ref:`Tables <syntax-tableinst>`
 ................................
 
-1. Let :math:`\tabletype` be the :ref:`table type <syntax-tabletype>` to allocate and :math:`\val` the initialization value.
+1. Let :math:`\tabletype` be the :ref:`table type <syntax-tabletype>` to allocate and :math:`\reff` the initialization value.
 
 2. Let :math:`(\{\LMIN~n, \LMAX~m^?\}~\reftype)` be the structure of :ref:`table type <syntax-tabletype>` :math:`\tabletype`.
 
 3. Let :math:`a` be the first free :ref:`table address <syntax-tableaddr>` in :math:`S`.
 
-4. Let :math:`\tableinst` be the :ref:`table instance <syntax-tableinst>` :math:`\{ \TIELEM~\REFNULL^n, \TIMAX~m^? \}` with :math:`n` empty elements.
+4. Let :math:`\tableinst` be the :ref:`table instance <syntax-tableinst>` :math:`\{ \TITYPE~\tabletype, \TIELEM~\reff^n \}` with :math:`n` elements set to :math:`\reff`.
 
 5. Append :math:`\tableinst` to the |STABLES| of :math:`S`.
 
@@ -373,11 +376,11 @@ New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tablei
 
 .. math::
    \begin{array}{rlll}
-   \alloctable(S, \tabletype, \val) &=& S', \tableaddr \\[1ex]
+   \alloctable(S, \tabletype, \reff) &=& S', \tableaddr \\[1ex]
    \mbox{where:} \hfill \\
    \tabletype &=& \{\LMIN~n, \LMAX~m^?\}~\reftype \\
    \tableaddr &=& |S.\STABLES| \\
-   \tableinst &=& \{ \TIELEM~\val^n, \TIMAX~m^? \} \\
+   \tableinst &=& \{ \TITYPE~\tabletype, \TIELEM~\reff^n \} \\
    S' &=& S \compose \{\STABLES~\tableinst\} \\
    \end{array}
 
@@ -394,7 +397,7 @@ New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tablei
 
 3. Let :math:`a` be the first free :ref:`memory address <syntax-memaddr>` in :math:`S`.
 
-4. Let :math:`\meminst` be the :ref:`memory instance <syntax-meminst>` :math:`\{ \MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}}, \MIMAX~m^? \}` that contains :math:`n` pages of zeroed :ref:`bytes <syntax-byte>`.
+4. Let :math:`\meminst` be the :ref:`memory instance <syntax-meminst>` :math:`\{ \MITYPE~\memtype, \MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}} \}` that contains :math:`n` pages of zeroed :ref:`bytes <syntax-byte>`.
 
 5. Append :math:`\meminst` to the |SMEMS| of :math:`S`.
 
@@ -406,7 +409,7 @@ New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tablei
    \mbox{where:} \hfill \\
    \memtype &=& \{\LMIN~n, \LMAX~m^?\} \\
    \memaddr &=& |S.\SMEMS| \\
-   \meminst &=& \{ \MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}}, \MIMAX~m^? \} \\
+   \meminst &=& \{ \MITYPE~\memtype, \MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}} \} \\
    S' &=& S \compose \{\SMEMS~\meminst\} \\
    \end{array}
 
@@ -419,23 +422,20 @@ New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tablei
 
 1. Let :math:`\globaltype` be the :ref:`global type <syntax-globaltype>` to allocate and :math:`\val` the :ref:`value <syntax-val>` to initialize the global with.
 
-2. Let :math:`\mut~t` be the structure of :ref:`global type <syntax-globaltype>` :math:`\globaltype`.
+2. Let :math:`a` be the first free :ref:`global address <syntax-globaladdr>` in :math:`S`.
 
-3. Let :math:`a` be the first free :ref:`global address <syntax-globaladdr>` in :math:`S`.
+3. Let :math:`\globalinst` be the :ref:`global instance <syntax-globalinst>` :math:`\{ \GITYPE~\globaltype, \GIVALUE~\val \}`.
 
-4. Let :math:`\globalinst` be the :ref:`global instance <syntax-globalinst>` :math:`\{ \GIVALUE~\val, \GIMUT~\mut \}`.
+4. Append :math:`\globalinst` to the |SGLOBALS| of :math:`S`.
 
-5. Append :math:`\globalinst` to the |SGLOBALS| of :math:`S`.
-
-6. Return :math:`a`.
+5. Return :math:`a`.
 
 .. math::
    \begin{array}{rlll}
    \allocglobal(S, \globaltype, \val) &=& S', \globaladdr \\[1ex]
    \mbox{where:} \hfill \\
-   \globaltype &=& \mut~t \\
    \globaladdr &=& |S.\SGLOBALS| \\
-   \globalinst &=& \{ \GIVALUE~\val, \GIMUT~\mut \} \\
+   \globalinst &=& \{ \GITYPE~\globaltype, \GIVALUE~\val \} \\
    S' &=& S \compose \{\SGLOBALS~\globalinst\} \\
    \end{array}
 
@@ -446,24 +446,27 @@ New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tablei
 Growing :ref:`tables <syntax-tableinst>`
 ........................................
 
-1. Let :math:`\tableinst` be the :ref:`table instance <syntax-tableinst>` to grow, :math:`n` the number of elements by which to grow it, and :math:`\val` the initialization value.
+1. Let :math:`\tableinst` be the :ref:`table instance <syntax-tableinst>` to grow, :math:`n` the number of elements by which to grow it, and :math:`\reff` the initialization value.
 
 2. Let :math:`\X{len}` be :math:`n` added to the length of :math:`\tableinst.\TIELEM`.
 
 3. If :math:`\X{len}` is larger than :math:`2^{32}`, then fail.
 
-4. If :math:`\tableinst.\TIMAX` is not empty and smaller than :math:`\X{len}`, then fail.
+4. Let :math:`\limits~t` be the structure of :ref:`memory type <syntax-memtype>` :math:`\tableinst.\TITYPE`.
 
-5. Append :math:`\REFNULL^n` to :math:`\tableinst.\TIELEM`.
+5. If :math:`\limits.\LMAX` is not empty and its value is smaller than :math:`\X{len}`, then fail.
+
+6. Append :math:`\reff^n` to :math:`\tableinst.\TIELEM`.
 
 .. math::
    \begin{array}{rllll}
-   \growtable(\tableinst, n, \val) &=& \tableinst \with \TIELEM = \tableinst.\TIELEM~\val^n \\
+   \growtable(\tableinst, n, \reff) &=& \tableinst \with \TIELEM = \tableinst.\TIELEM~\reff^n \\
      && (
        \begin{array}[t]{@{}r@{~}l@{}}
        \iff & \X{len} = n + |\tableinst.\TIELEM| \\
        \wedge & \X{len} \leq 2^{32} \\
-       \wedge & (\tableinst.\TIMAX = \epsilon \vee \X{len} \leq \tableinst.\TIMAX)) \\
+       \wedge & \limits~t = \tableinst.\TITYPE \\
+       \wedge & (\limits.\LMAX = \epsilon \vee \X{len} \leq \limits.\LMAX)) \\
        \end{array} \\
    \end{array}
 
@@ -482,9 +485,11 @@ Growing :ref:`memories <syntax-meminst>`
 
 4. If :math:`\X{len}` is larger than :math:`2^{16}`, then fail.
 
-5. If :math:`\meminst.\MIMAX` is not empty and its value is smaller than :math:`\X{len}`, then fail.
+5. Let :math:`\limits` be the structure of :ref:`memory type <syntax-memtype>` :math:`\meminst.\MITYPE`.
 
-6. Append :math:`n` times :math:`64\,\F{Ki}` :ref:`bytes <syntax-byte>` with value :math:`\hex{00}` to :math:`\meminst.\MIDATA`.
+6. If :math:`\limits.\LMAX` is not empty and its value is smaller than :math:`\X{len}`, then fail.
+
+7. Append :math:`n` times :math:`64\,\F{Ki}` :ref:`bytes <syntax-byte>` with value :math:`\hex{00}` to :math:`\meminst.\MIDATA`.
 
 .. math::
    \begin{array}{rllll}
@@ -493,7 +498,8 @@ Growing :ref:`memories <syntax-meminst>`
        \begin{array}[t]{@{}r@{~}l@{}}
        \iff & \X{len} = n + |\meminst.\MIDATA| / 64\,\F{Ki} \\
        \wedge & \X{len} \leq 2^{16} \\
-       \wedge & (\meminst.\MIMAX = \epsilon \vee \X{len} \leq \meminst.\MIMAX)) \\
+       \wedge & \limits = \meminst.\MITYPE \\
+       \wedge & (\limits.\LMAX = \epsilon \vee \X{len} \leq \limits.\LMAX)) \\
        \end{array} \\
    \end{array}
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -249,18 +249,18 @@ Table Instances
 ~~~~~~~~~~~~~~~
 
 A *table instance* is the runtime representation of a :ref:`table <syntax-table>`.
-It holds a vector of *function elements* and an optional maximum size, if one was specified in the :ref:`table type <syntax-tabletype>` at the table's definition site.
-
-Each table element is a :ref:`reference value <syntax-ref>`.
-Table elements can be mutated through :ref:`table instructions <syntax-instr-table>`, the execution of an :ref:`element segment <syntax-elem>`, or by external means provided by the :ref:`embedder <embedder>`.
+It records its :ref:`type <syntax-tabletype>` and holds a vector of :ref:`reference values <syntax-ref>`.
 
 .. math::
    \begin{array}{llll}
    \production{(table instance)} & \tableinst &::=&
-     \{ \TIELEM~\vec(\reff), \TIMAX~\u32^? \} \\
+     \{ \TITYPE~\tabletype, \TIELEM~\vec(\reff) \} \\
    \end{array}
 
-It is an invariant of the semantics that the length of the element vector never exceeds the maximum size, if present.
+Table elements can be mutated through :ref:`table instructions <syntax-instr-table>`, the execution of an active :ref:`element segment <syntax-elem>`, or by external means provided by the :ref:`embedder <embedder>`.
+
+It is an invariant of the semantics that all table elements have a type :ref:`matching <match-reftype>` the element type of :math:`\tabletype`.
+It also is an invariant that the length of the element vector never exceeds the maximum size of :math:`\tabletype`, if present.
 
 
 .. index:: ! memory instance, memory, byte, ! page size, memory type, embedder, data segment, instruction
@@ -273,20 +273,19 @@ Memory Instances
 ~~~~~~~~~~~~~~~~
 
 A *memory instance* is the runtime representation of a linear :ref:`memory <syntax-mem>`.
-It holds a vector of :ref:`bytes <syntax-byte>` and an optional maximum size, if one was specified at the definition site of the memory.
+It records its :ref:`type <syntax-memtype>` and holds a vector of :ref:`bytes <syntax-byte>`.
 
 .. math::
    \begin{array}{llll}
    \production{(memory instance)} & \meminst &::=&
-     \{ \MIDATA~\vec(\byte), \MIMAX~\u32^? \} \\
+     \{ \MITYPE~\memtype, \MIDATA~\vec(\byte) \} \\
    \end{array}
 
 The length of the vector always is a multiple of the WebAssembly *page size*, which is defined to be the constant :math:`65536` -- abbreviated :math:`64\,\F{Ki}`.
-Like in a :ref:`memory type <syntax-memtype>`, the maximum size in a memory instance is given in units of this page size.
 
-The bytes can be mutated through :ref:`memory instructions <syntax-instr-memory>`, the execution of a :ref:`data segment <syntax-data>`, or by external means provided by the :ref:`embedder <embedder>`.
+The bytes can be mutated through :ref:`memory instructions <syntax-instr-memory>`, the execution of an active :ref:`data segment <syntax-data>`, or by external means provided by the :ref:`embedder <embedder>`.
 
-It is an invariant of the semantics that the length of the byte vector, divided by page size, never exceeds the maximum size, if present.
+It is an invariant of the semantics that the length of the byte vector, divided by page size, never exceeds the maximum size of :math:`\memtype`, if present.
 
 
 .. index:: ! global instance, global, value, mutability, instruction, embedder
@@ -298,15 +297,17 @@ Global Instances
 ~~~~~~~~~~~~~~~~
 
 A *global instance* is the runtime representation of a :ref:`global <syntax-global>` variable.
-It holds an individual :ref:`value <syntax-val>` and a flag indicating whether it is mutable.
+It records its :ref:`type <syntax-globaltype>` and holds an individual :ref:`value <syntax-val>`.
 
 .. math::
    \begin{array}{llll}
    \production{(global instance)} & \globalinst &::=&
-     \{ \GIVALUE~\val, \GIMUT~\mut \} \\
+     \{ \GITYPE~\valtype, \GIVALUE~\val \} \\
    \end{array}
 
 The value of mutable globals can be mutated through :ref:`variable instructions <syntax-instr-variable>` or by external means provided by the :ref:`embedder <embedder>`.
+
+It is an invariant of the semantics that the value has a type :ref:`matching <match-valtype>` the :ref:`value type <syntax-valtype>` of :math:`\globaltype`.
 
 
 .. index:: ! export instance, export, name, external value

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -806,14 +806,14 @@
 .. |FICODE| mathdef:: \xref{exec/runtime}{syntax-funcinst}{\K{code}}
 .. |FIHOSTCODE| mathdef:: \xref{exec/runtime}{syntax-funcinst}{\K{hostcode}}
 
+.. |TITYPE| mathdef:: \xref{exec/runtime}{syntax-tableinst}{\K{type}}
 .. |TIELEM| mathdef:: \xref{exec/runtime}{syntax-tableinst}{\K{elem}}
-.. |TIMAX| mathdef:: \xref{exec/runtime}{syntax-tableinst}{\K{max}}
 
+.. |MITYPE| mathdef:: \xref{exec/runtime}{syntax-meminst}{\K{type}}
 .. |MIDATA| mathdef:: \xref{exec/runtime}{syntax-meminst}{\K{data}}
-.. |MIMAX| mathdef:: \xref{exec/runtime}{syntax-meminst}{\K{max}}
 
+.. |GITYPE| mathdef:: \xref{exec/runtime}{syntax-globalinst}{\K{type}}
 .. |GIVALUE| mathdef:: \xref{exec/runtime}{syntax-globalinst}{\K{value}}
-.. |GIMUT| mathdef:: \xref{exec/runtime}{syntax-globalinst}{\K{mut}}
 
 .. |EINAME| mathdef:: \xref{exec/runtime}{syntax-exportinst}{\K{name}}
 .. |EIVALUE| mathdef:: \xref{exec/runtime}{syntax-exportinst}{\K{value}}


### PR DESCRIPTION
With the introduction of subtyping, the semantics can no longer infer the type of a global or table instance at runtime from its value or elements. Instead, table and global instances must be equipped with that type information explicitly (for uniformity, do the same for memories). This comes up both during import matching and in auxiliary judgements accompanying the soundness theorem.

(This change aligns with what we already have in the reference interpreter.)

Some minor oversights fixed as well.