### PR TITLE
Fix module name in test

### DIFF
--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -93,18 +93,18 @@
 )
 
 
-(module $ref_ex
+(module $Mref_ex
   (global (export "g-const") funcref (ref.null))
   (global (export "g-var") (mut funcref) (ref.null))
 )
-(register "ref_ex" $ref_ex)
+(register "Mref_ex" $Mref_ex)
 
-(module $ref_im
-  (global (import "ref_ex" "g-const") anyref)
+(module $Mref_im
+  (global (import "Mref_ex" "g-const") anyref)
 )
 
 (assert_unlinkable
-  (module (global (import "ref_ex" "g-var") (mut anyref)))
+  (module (global (import "Mref_ex" "g-var") (mut anyref)))
   "incompatible import type"
 )
 

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -93,18 +93,18 @@
 )
 
 
-(module $Mref-ex
+(module $ref_ex
   (global (export "g-const") funcref (ref.null))
   (global (export "g-var") (mut funcref) (ref.null))
 )
-(register "Mref-ex" $Mref-ex)
+(register "ref_ex" $ref_ex)
 
-(module $Mref-im
-  (global (import "Mref-ex" "g-const") anyref)
+(module $ref_im
+  (global (import "ref_ex" "g-const") anyref)
 )
 
 (assert_unlinkable
-  (module (global (import "Mref-ex" "g-var") (mut anyref)))
+  (module (global (import "ref_ex" "g-var") (mut anyref)))
   "incompatible import type"
 )
 


### PR DESCRIPTION
The module name in linking.wast wasm `Mref-ex`. This is not a valid variable name in JavaScript. I replaced the `-` with a `_`.