### PR TITLE
[test] Use more JS-compatible names

### DIFF
--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -109,14 +109,14 @@
 )
 
 
-(module $Mglobal-ex
+(module $Mglobal_ex
   (func $f)
   (global (export "g") anyref (ref.func $f))
 )
-(register "Mglobal-ex" $Mglobal-ex)
+(register "Mglobal_ex" $Mglobal_ex)
 
 (assert_unlinkable
-  (module (global (import "Mglobal-ex" "g") funcref))
+  (module (global (import "Mglobal_ex" "g") funcref))
   "incompatible import type"
 )
 
@@ -277,15 +277,15 @@
 (assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized")
 
 
-(module $Mtable-ex
+(module $Mtable_ex
   (func $f)
   (table $t (export "t") 1 anyref)
   (elem (i32.const 0) $f)
 )
-(register "Mtable-ex" $Mtable-ex)
+(register "Mtable_ex" $Mtable_ex)
 
 (assert_unlinkable
-  (module (table (import "Mtable-ex" "t") 1 funcref))
+  (module (table (import "Mtable_ex" "t") 1 funcref))
   "incompatible import type"
 )
 


### PR DESCRIPTION
Apparently I missed some JS-incompatible names in https://github.com/WebAssembly/reference-types/pull/45.