### PR TITLE
Adjust element segment encoding to match the bulk-memory proposal

### DIFF
--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -321,7 +321,7 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
    \production{element segment} & \Belem &::=&
      \hex{00}~~e{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \{ \ETABLE~0, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
-     \hex{02}~~x{:}\Btableidx~~e{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
+     \hex{02}~~x{:}\Btableidx~~e{:}\Bexpr~~\hex{00}~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \{ \ETABLE~x, \EOFFSET~e, \EINIT~y^\ast \} \\
    \end{array}
 

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -550,6 +550,10 @@ let table s =
 let table_section s =
   section `TableSection (vec (at table)) [] s
 
+let elem_kind s =
+  match vs7 s with
+  | 0x00 -> FuncRefType
+  | _ -> error s (pos s - 1) "invalid elem kind"
 
 (* Memory section *)
 
@@ -621,21 +625,23 @@ let code_section s =
 
 (* Element section *)
 
-let segment dat s =
-  let pos = pos s in
-  let x = at vu32 s in
-  let index =
-    match x.Source.it with
-    | 0l -> x
-    | 2l -> at var s
-    | _ -> error s pos "invalid segment kind"
-  in
-  let offset = const s in
-  let init = dat s in
-  {index; offset; init}
+let segment dat kind s =
+  match vu32 s with
+  | 0l ->
+    let index = Source.(0l @@ Source.no_region) in
+    let offset = const s in
+    let init = dat s in
+    {index; offset; init}
+  | 2l ->
+    let index = at var s in
+    let offset = const s in
+    let _ = kind s in
+    let init = dat s in
+    {index; offset; init}
+  | _ -> error s (pos s - 1) "invalid segment kind"
 
 let table_segment s =
-  segment (vec (at var)) s
+  segment (vec (at var)) elem_kind s
 
 let elem_section s =
   section `ElemSection (vec (at table_segment)) [] s
@@ -644,7 +650,7 @@ let elem_section s =
 (* Data section *)
 
 let memory_segment s =
-  segment string s
+  segment string (fun s -> ()) s
 
 let data_section s =
   section `DataSection (vec (at memory_segment)) [] s

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -626,13 +626,13 @@ let code_section s =
 (* Element section *)
 
 let segment dat kind s =
-  match vu32 s with
-  | 0l ->
+  match u8 s with
+  | 0 ->
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let init = dat s in
     {index; offset; init}
-  | 2l ->
+  | 2 ->
     let index = at var s in
     let offset = const s in
     let _ = kind s in

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -490,13 +490,11 @@ let encode m =
 
     (* Element section *)
     let segment dat seg =
-      let {index; offset; init} = seg.it in
-      if index.it = 0l then
-        u8 0x00
-      else begin
-        u8 0x02; var index
-      end;
-      const offset; dat init
+      match seg.it with
+      | {index = {it = 0l;_}; offset; init} ->
+        u8 0x00; const offset; dat init
+      | {index; offset; init} ->
+        u8 0x02; var index; const offset; u8 0x00; dat init
 
     let table_segment seg =
       segment (vec var) seg

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -491,7 +491,7 @@ let encode m =
     (* Element section *)
     let segment dat seg =
       match seg.it with
-      | {index = {it = 0l;_}; offset; init} ->
+      | {index; offset; init} when index.it = 0l ->
         u8 0x00; const offset; dat init
       | {index; offset; init} ->
         u8 0x02; var index; const offset; u8 0x00; dat init

--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -114,14 +114,22 @@
   "\0b"                                ;; end
 )
 
-;; Data segment memory index can have non-minimal length
 (module binary
   "\00asm" "\01\00\00\00"
   "\05\03\01"                          ;; Memory section with 1 entry
   "\00\00"                             ;; no max, minimum 0
-  "\0b\07\01"                          ;; Data section with 1 entry
-  "\80\00"                             ;; Memory index 0, encoded with 2 bytes
+  "\0b\06\01"                          ;; Data section with 1 entry
+  "\00"                                ;; Memory index 0
   "\41\00\0b\00"                       ;; (i32.const 0) with contents ""
+)
+
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\04\04\01"                          ;; Table section with 1 entry
+  "\70\00\00"                          ;; no max, minimum 0, funcref
+  "\09\06\01"                          ;; Element section with 1 entry
+  "\00"                                ;; Table index 0
+  "\41\00\0b\00"                       ;; (i32.const 0) with no elements
 )
 
 ;; Element segment table index can have non-minimal length
@@ -129,9 +137,9 @@
   "\00asm" "\01\00\00\00"
   "\04\04\01"                          ;; Table section with 1 entry
   "\70\00\00"                          ;; no max, minimum 0, funcref
-  "\09\07\01"                          ;; Element section with 1 entry
-  "\80\00"                             ;; Table index 0, encoded with 2 bytes
-  "\41\00\0b\00"                       ;; (i32.const 0) with no elements
+  "\09\09\01"                          ;; Element section with 1 entry
+  "\02\80\00"                          ;; Table index 0, encoded with 2 bytes
+  "\41\00\0b\00\00"                       ;; (i32.const 0) with no elements
 )
 
 ;; Unsigned LEB128 must not be overlong


### PR DESCRIPTION
Due to recent changes in the bulk-memory proposal (https://github.com/WebAssembly/bulk-memory-operations/pull/109), the element segment encoding here does not match the one in the bulk-memory proposal anymore. Concretely, element segments with flag 0x02 have an additional 0x00 byte after the offset which is a place holder for a potential element kind field.

This PR does minimal changes to get the reference-types proposal and the bulk-memory proposal in sync again.