### PR TITLE
[test] Add negative test for ref.func globals

### DIFF
--- a/test/core/ref_func.wast
+++ b/test/core/ref_func.wast
@@ -53,3 +53,12 @@
 (assert_return (invoke "call-v" (i32.const 4)) (i32.const 5))
 (invoke "set-f")
 (assert_return (invoke "call-v" (i32.const 4)) (i32.const 4))
+
+(assert_invalid
+  (module
+    (func $f (import "M" "f") (param i32) (result i32))
+    (func $g (import "M" "g") (param i32) (result i32))
+    (global funcref (ref.func 7))
+  )
+  "unknown function 7"
+)


### PR DESCRIPTION
Add a test with an invalid function index in a ref.func init expression.