### PR TITLE
Fix various TODOs

### DIFF
--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -286,8 +286,6 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 .. index:: element instance, reference
 .. _valid-eleminst:
 
-.. todo:: TODO: adjust elem instances
-
 :ref:`Element Instances <syntax-eleminst>` :math:`\{ \EIELEM~\X{fa}^\ast \}`
 ............................................................................
 
@@ -303,7 +301,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
    \frac{
      (S \vdash \reff : t')^\ast
      \qquad
-     (\vdashreftypematch t' \matchesvaltype t)^n
+     (\vdashreftypematch t' \matchesvaltype t)^\ast
    }{
      S \vdasheleminst \{ \EITYPE~t, \EIELEM~\reff^\ast \} \ok
    }

--- a/document/core/exec/conventions.rst
+++ b/document/core/exec/conventions.rst
@@ -33,7 +33,7 @@ The following conventions are adopted in stating these rules.
 
 * The execution rules also assume the presence of an implicit :ref:`stack <stack>`
   that is modified by *pushing* or *popping*
-  :ref:`values <syntax-value>`, :ref:`function elements <syntax-funcelem>`, :ref:`labels <syntax-label>`, and :ref:`frames <syntax-frame>`.
+  :ref:`values <syntax-value>`, :ref:`labels <syntax-label>`, and :ref:`frames <syntax-frame>`.
 
 * Certain rules require the stack to contain at least one frame.
   The most recent frame is referred to as the *current* frame.

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -633,11 +633,11 @@ Table Instructions
 
 2. Assert: due to :ref:`validation <valid-table.fill>`, :math:`F.\AMODULE.\MITABLES[x]` exists.
 
-3. Let :math:`a` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[x]`.
+3. Let :math:`\X{ta}` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[x]`.
 
-4. Assert: due to :ref:`validation <valid-table.fill>`, :math:`S.\STABLES[a]` exists.
+4. Assert: due to :ref:`validation <valid-table.fill>`, :math:`S.\STABLES[\X{ta}]` exists.
 
-5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[a]`.
+5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}]`.
 
 6. Assert: due to :ref:`validation <valid-table.fill>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
@@ -693,50 +693,56 @@ Table Instructions
 
 .. _exec-table.copy:
 
-:math:`\TABLECOPY`
-..................
-
-.. todo:: TODO: multi tables
+:math:`\TABLECOPY~x~y`
+......................
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. Assert: due to :ref:`validation <valid-table.copy>`, :math:`F.\AMODULE.\MITABLES[0]` exists.
+2. Assert: due to :ref:`validation <valid-table.copy>`, :math:`F.\AMODULE.\MITABLES[x]` exists.
 
-3. Let :math:`\X{ta}` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[0]`.
+3. Let :math:`\X{ta}_d` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[x]`.
 
-4. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}]` exists.
+4. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}_d]` exists.
 
-5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}]`.
+5. Let :math:`\X{tab}_d` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_d]`.
 
-6. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+7. Assert: due to :ref:`validation <valid-table.copy>`, :math:`F.\AMODULE.\MITABLES[y]` exists.
 
-7. Pop the value :math:`\I32.\CONST~n` from the stack.
+8. Let :math:`\X{ta}_s` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[y]`.
 
-8. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+9. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}_s]` exists.
 
-9. Pop the value :math:`\I32.\CONST~s` from the stack.
+10. Let :math:`\X{tab}_s` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_s]`.
 
-10. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+11. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
-11. Pop the value :math:`\I32.\CONST~d` from the stack.
+12. Pop the value :math:`\I32.\CONST~n` from the stack.
 
-12. If :math:`s + n` is larger than the length of :math:`\X{tab}.\TIELEM` or :math:`d + n` is larger than the length of :math:`\X{tab}.\TIELEM`, then:
+13. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+14. Pop the value :math:`\I32.\CONST~s` from the stack.
+
+15. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+16. Pop the value :math:`\I32.\CONST~d` from the stack.
+
+17. If :math:`s + n` is larger than the length of :math:`\X{tab}_s.\TIELEM` or :math:`d + n` is larger than the length of :math:`\X{tab}_d.\TIELEM`, then:
 
     a. Trap.
 
-13. If :math:`n = 0`, then:
+18. If :math:`n = 0`, then:
 
    a. Return.
 
-14. If :math:`d \leq s`, then:
+19. If :math:`d \leq s`, then:
 
    a. Push the value :math:`\I32.\CONST~d` to the stack.
 
    b. Push the value :math:`\I32.\CONST~s` to the stack.
 
-   c. Execute the instruction :math:`\TABLEGET`.
+   c. Execute the instruction :math:`\TABLEGET~y`.
 
-   d. Execute the instruction :math:`\TABLESET`.
+   d. Execute the instruction :math:`\TABLESET~x`.
 
    e. Assert: due to the earlier check against the table size, :math:`d+1 < 2^{32}`.
 
@@ -746,7 +752,7 @@ Table Instructions
 
    h. Push the value :math:`\I32.\CONST~(s+1)` to the stack.
 
-15. Else:
+20. Else:
 
    a. Assert: due to the earlier check against the table size, :math:`d+n-1 < 2^{32}`.
 
@@ -756,48 +762,48 @@ Table Instructions
 
    d. Push the value :math:`\I32.\CONST~(s+n-1)` to the stack.
 
-   c. Execute the instruction :math:`\TABLEGET`.
+   c. Execute the instruction :math:`\TABLEGET~y`.
 
-   f. Execute the instruction :math:`\TABLESET`.
+   f. Execute the instruction :math:`\TABLESET~x`.
 
    g. Push the value :math:`\I32.\CONST~d` to the stack.
 
    h. Push the value :math:`\I32.\CONST~s` to the stack.
 
-16. Push the value :math:`\I32.\CONST~(n-1)` to the stack.
+21. Push the value :math:`\I32.\CONST~(n-1)` to the stack.
 
-17. Execute the instruction :math:`\TABLECOPY`.
+22. Execute the instruction :math:`\TABLECOPY~x~y`.
 
 .. math::
    ~\\[-1ex]
    \begin{array}{l}
-   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n)~\TABLECOPY
+   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n)~(\TABLECOPY~x~y)
      \quad\stepto\quad S; F; \TRAP
      \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\iff & s + n > |S.\STABLES[F.\AMODULE.\MITABLES[0]].\TIELEM| \\
-      \vee & d + n > |S.\STABLES[F.\AMODULE.\MITABLES[0]].\TIELEM|) \\
+     (\iff & s + n > |S.\STABLES[F.\AMODULE.\MITABLES[y]].\TIELEM| \\
+      \vee & d + n > |S.\STABLES[F.\AMODULE.\MITABLES[x]].\TIELEM|) \\
      \end{array}
    \\[1ex]
-   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~0)~\TABLECOPY
+   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~0)~(\TABLECOPY~x~y)
      \quad\stepto\quad S; F; \epsilon
      \\ \qquad
      (\otherwise)
    \\[1ex]
-   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n+1)~\TABLECOPY
+   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n+1)~(\TABLECOPY~x~y)
      \quad\stepto\quad S; F;
        \begin{array}[t]{@{}l@{}}
-       (\I32.\CONST~d)~(\I32.\CONST~s)~\TABLEGET~\TABLESET \\
-       (\I32.\CONST~d+1)~(\I32.\CONST~s+1)~(\I32.\CONST~n)~\TABLECOPY \\
+       (\I32.\CONST~d)~(\I32.\CONST~s)~(\TABLEGET~y)~(\TABLESET~x) \\
+       (\I32.\CONST~d+1)~(\I32.\CONST~s+1)~(\I32.\CONST~n)~(\TABLECOPY~x~y) \\
        \end{array}
      \\ \qquad
      (\otherwise, \iff d \leq s)
    \\[1ex]
-   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n+1)~\TABLECOPY
+   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n+1)~(\TABLECOPY~x~y)
      \quad\stepto\quad S; F;
        \begin{array}[t]{@{}l@{}}
-       (\I32.\CONST~d+n-1)~(\I32.\CONST~s+n-1)~\TABLEGET~\TABLESET \\
-       (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n)~\TABLECOPY \\
+       (\I32.\CONST~d+n-1)~(\I32.\CONST~s+n-1)~(\TABLEGET~y)~(\TABLESET~x) \\
+       (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n)~(\TABLECOPY~x~y) \\
        \end{array}
      \\ \qquad
      (\otherwise, \iff d > s) \\
@@ -806,24 +812,22 @@ Table Instructions
 
 .. _exec-table.init:
 
-:math:`\TABLEINIT~x`
-....................
-
-.. todo:: TODO: multi tables
+:math:`\TABLEINIT~x~y`
+......................
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. Assert: due to :ref:`validation <valid-table.init>`, :math:`F.\AMODULE.\MITABLES[0]` exists.
+2. Assert: due to :ref:`validation <valid-table.init>`, :math:`F.\AMODULE.\MITABLES[x]` exists.
 
-3. Let :math:`\X{ta}` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[0]`.
+3. Let :math:`\X{ta}` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[x]`.
 
 4. Assert: due to :ref:`validation <valid-table.init>`, :math:`S.\STABLES[\X{ta}]` exists.
 
 5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}]`.
 
-6. Assert: due to :ref:`validation <valid-table.init>`, :math:`F.\AMODULE.\MIELEMS[x]` exists.
+6. Assert: due to :ref:`validation <valid-table.init>`, :math:`F.\AMODULE.\MIELEMS[y]` exists.
 
-7. Let :math:`\X{ea}` be the :ref:`element address <syntax-elemaddr>` :math:`F.\AMODULE.\MIELEMS[x]`.
+7. Let :math:`\X{ea}` be the :ref:`element address <syntax-elemaddr>` :math:`F.\AMODULE.\MIELEMS[y]`.
 
 8. Assert: due to :ref:`validation <valid-table.init>`, :math:`S.\SELEMS[\X{ea}]` exists.
 
@@ -849,13 +853,13 @@ Table Instructions
 
     a. Return.
 
-18. Let :math:`\funcelem` be the :ref:`function element <syntax-funcelem>` :math:`\X{elem}.\EIELEM[s]`.
+18. Let :math:`\val` be the :ref:`reference value <syntax-ref>` :math:`\X{elem}.\EIELEM[s]`.
 
 19. Push the value :math:`\I32.\CONST~d` to the stack.
 
-20. Push the value :math:`\funcelem` to the stack.
+20. Push the value :math:`\val` to the stack.
 
-21. Execute the instruction :math:`\TABLESET`.
+21. Execute the instruction :math:`\TABLESET~x`.
 
 22. Assert: due to the earlier check against the table size, :math:`d+1 < 2^{32}`.
 
@@ -867,32 +871,32 @@ Table Instructions
 
 26. Push the value :math:`\I32.\CONST~(n-1)` to the stack.
 
-27. Execute the instruction :math:`\TABLEINIT~x`.
+27. Execute the instruction :math:`\TABLEINIT~x~y`.
 
 .. math::
    ~\\[-1ex]
    \begin{array}{l}
-   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n)~(\TABLEINIT~x)
+   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n)~(\TABLEINIT~x~y)
      \quad\stepto\quad S; F; \TRAP
      \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\iff & s + n > |S.\SELEMS[F.\AMODULE.\MIELEMS[x]].\EIELEM| \\
+     (\iff & s + n > |S.\SELEMS[F.\AMODULE.\MIELEMS[y]].\EIELEM| \\
       \vee & d + n > |S.\STABLES[F.\AMODULE.\MITABLES[x]].\TIELEM|) \\
      \end{array}
    \\[1ex]
-   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~0)~(\TABLEINIT~x)
+   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~0)~(\TABLEINIT~x~y)
      \quad\stepto\quad S; F; \epsilon
      \\ \qquad
      (\otherwise)
    \\[1ex]
-   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n+1)~(\TABLEINIT~x)
+   S; F; (\I32.\CONST~d)~(\I32.\CONST~s)~(\I32.\CONST~n+1)~(\TABLEINIT~x~y)
      \quad\stepto\quad S; F;
        \begin{array}[t]{@{}l@{}}
-       (\I32.\CONST~d)~\funcelem~(\TABLESET~x) \\
-       (\I32.\CONST~d+1)~(\I32.\CONST~s+1)~(\I32.\CONST~n)~(\TABLEINIT~x) \\
+       (\I32.\CONST~d)~\val~(\TABLESET~x) \\
+       (\I32.\CONST~d+1)~(\I32.\CONST~s+1)~(\I32.\CONST~n)~(\TABLEINIT~x~y) \\
        \end{array}
      \\ \qquad
-     (\otherwise, \iff \funcelem = S.\SELEMS[F.\AMODULE.\MIELEMS[x]].\EIELEM[s]) \\
+     (\otherwise, \iff \val = S.\SELEMS[F.\AMODULE.\MIELEMS[x]].\EIELEM[s]) \\
    \end{array}
 
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -706,35 +706,35 @@ Table Instructions
 
 5. Let :math:`\X{tab}_d` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_d]`.
 
-7. Assert: due to :ref:`validation <valid-table.copy>`, :math:`F.\AMODULE.\MITABLES[y]` exists.
+6. Assert: due to :ref:`validation <valid-table.copy>`, :math:`F.\AMODULE.\MITABLES[y]` exists.
 
-8. Let :math:`\X{ta}_s` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[y]`.
+7. Let :math:`\X{ta}_s` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[y]`.
 
-9. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}_s]` exists.
+8. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}_s]` exists.
 
-10. Let :math:`\X{tab}_s` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_s]`.
+9. Let :math:`\X{tab}_s` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_s]`.
 
-11. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+10. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
-12. Pop the value :math:`\I32.\CONST~n` from the stack.
+11. Pop the value :math:`\I32.\CONST~n` from the stack.
 
-13. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+12. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
-14. Pop the value :math:`\I32.\CONST~s` from the stack.
+13. Pop the value :math:`\I32.\CONST~s` from the stack.
 
-15. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+14. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
-16. Pop the value :math:`\I32.\CONST~d` from the stack.
+15. Pop the value :math:`\I32.\CONST~d` from the stack.
 
-17. If :math:`s + n` is larger than the length of :math:`\X{tab}_s.\TIELEM` or :math:`d + n` is larger than the length of :math:`\X{tab}_d.\TIELEM`, then:
+16. If :math:`s + n` is larger than the length of :math:`\X{tab}_s.\TIELEM` or :math:`d + n` is larger than the length of :math:`\X{tab}_d.\TIELEM`, then:
 
     a. Trap.
 
-18. If :math:`n = 0`, then:
+17. If :math:`n = 0`, then:
 
    a. Return.
 
-19. If :math:`d \leq s`, then:
+18. If :math:`d \leq s`, then:
 
    a. Push the value :math:`\I32.\CONST~d` to the stack.
 
@@ -752,7 +752,7 @@ Table Instructions
 
    h. Push the value :math:`\I32.\CONST~(s+1)` to the stack.
 
-20. Else:
+19. Else:
 
    a. Assert: due to the earlier check against the table size, :math:`d+n-1 < 2^{32}`.
 
@@ -770,9 +770,9 @@ Table Instructions
 
    h. Push the value :math:`\I32.\CONST~s` to the stack.
 
-21. Push the value :math:`\I32.\CONST~(n-1)` to the stack.
+20. Push the value :math:`\I32.\CONST~(n-1)` to the stack.
 
-22. Execute the instruction :math:`\TABLECOPY~x~y`.
+21. Execute the instruction :math:`\TABLECOPY~x~y`.
 
 .. math::
    ~\\[-1ex]

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -700,19 +700,19 @@ Table Instructions
 
 2. Assert: due to :ref:`validation <valid-table.copy>`, :math:`F.\AMODULE.\MITABLES[x]` exists.
 
-3. Let :math:`\X{ta}_d` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[x]`.
+3. Let :math:`\X{ta}_x` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[x]`.
 
-4. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}_d]` exists.
+4. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}_x]` exists.
 
-5. Let :math:`\X{tab}_d` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_d]`.
+5. Let :math:`\X{tab}_x` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_x]`.
 
 6. Assert: due to :ref:`validation <valid-table.copy>`, :math:`F.\AMODULE.\MITABLES[y]` exists.
 
-7. Let :math:`\X{ta}_s` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[y]`.
+7. Let :math:`\X{ta}_y` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[y]`.
 
-8. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}_s]` exists.
+8. Assert: due to :ref:`validation <valid-table.copy>`, :math:`S.\STABLES[\X{ta}_y]` exists.
 
-9. Let :math:`\X{tab}_s` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_s]`.
+9. Let :math:`\X{tab}_y` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}_y]`.
 
 10. Assert: due to :ref:`validation <valid-table.copy>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
@@ -726,7 +726,7 @@ Table Instructions
 
 15. Pop the value :math:`\I32.\CONST~d` from the stack.
 
-16. If :math:`s + n` is larger than the length of :math:`\X{tab}_s.\TIELEM` or :math:`d + n` is larger than the length of :math:`\X{tab}_d.\TIELEM`, then:
+16. If :math:`s + n` is larger than the length of :math:`\X{tab}_y.\TIELEM` or :math:`d + n` is larger than the length of :math:`\X{tab}_x.\TIELEM`, then:
 
     a. Trap.
 

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -630,21 +630,21 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
 6. Let :math:`(\reff^\ast)^\ast` be the list of :ref:`reference <syntax-ref>` vectors determined by the :ref:`element segments <syntax-elem>` in :math:`\module`. These may be calculated as follows.
 
-    .. todo:: TODO desugar funcelem
+    a. Let :math:`\moduleinst_{\F{im}}` be the auxiliary module :ref:`instance <syntax-moduleinst>` :math:`\{\MIGLOBALS~\evglobals(\externval^n)\}` that only consists of the imported globals.
 
-    a. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEMS`, and for each element :ref:`expression <syntax-expr>` :math:`\expr_{ij}` in :math:`\elem_i.\EINIT`, do:
+    b. Let :math:`F_{\F{im}}` be the auxiliary :ref:`frame <syntax-frame>` :math:`\{ \AMODULE~\moduleinst_{\F{im}}, \ALOCALS~\epsilon \}`.
 
-       i. If :math:`\expr_{ij}` is of the form :math:`\REFNULL`, then let the :ref:`function element <syntax-funcelem>` :math:`\funcelem_{ij}` be :math:`\epsilon`.
+    c. Push the frame :math:`F_{\F{im}}` to the stack.
 
-       ii. Else, :math:`\expr_{ij}` is of the form is :math:`\REFFUNC~\funcidx_{ij}`.
+    d. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEMS`, and for each element :ref:`expression <syntax-expr>` :math:`\expr_{ij}` in :math:`\elem_i.\EINIT`, do:
 
-       iii. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MIFUNCS[\funcidx_{ij}]` exists.
+       i. Let :math:`\reff_{ij}` be the result of :ref:`evaluating <exec-expr>` the initializer expression :math:`\expr_{ij}`.
 
-       iv. Let the :ref:`function element <syntax-funcelem>` :math:`\funcelem_{ij}` be the :ref:`function address <syntax-funcaddr>` :math:`\moduleinst.\MIFUNCS[\funcidx_{ij}]`.
+    e. Pop the frame :math:`F_{\F{im}}` from the stack.
 
-    b. Let :math:`\funcelem^\ast_i` be the concatenation of function elements :math:`\funcelem_{ij}` in order of index :math:`j`.
+    f. Let :math:`\reff^\ast_i` be the concatenation of function elements :math:`\reff_{ij}` in order of index :math:`j`.
 
-    c. Let :math:`(\funcelem^\ast)^\ast` be the concatenation of function element vectors :math:`\funcelem^\ast_i` in order of index :math:`i`.
+    g. Let :math:`(\reff^\ast)^\ast` be the concatenation of function element vectors :math:`\reff^\ast_i` in order of index :math:`i`.
 
 7. Let :math:`\moduleinst` be a new module instance :ref:`allocated <alloc-module>` from :math:`\module` in store :math:`S` with imports :math:`\externval^n`, global initializer values :math:`\val^\ast`, and element segment contents :math:`(\reff^\ast)^\ast`, and let :math:`S'` be the extended store produced by module allocation.
 
@@ -711,10 +711,13 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
      &\wedge& \module.\MGLOBALS = \global^\ast \\
      &\wedge& \module.\MELEMS = \elem^n \\
      &\wedge& \module.\MDATAS = \data^m \\
-     &\wedge& \module.\MSTART = \start^? \\[1ex]
-     &\wedge& S', \moduleinst = \allocmodule(S, \module, \externval^k, \val^\ast) \\
+     &\wedge& \module.\MSTART = \start^? \\
+     &\wedge& (\expr_{\F{g}} = \global.GINIT)^\ast \\
+     &\wedge& (\expr_{\F{e}}^\ast = \elem.EINIT)^n \\[1ex]
+     &\wedge& S', \moduleinst = \allocmodule(S, \module, \externval^k, \val^\ast, (\reff^\ast)^n) \\
      &\wedge& F = \{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \} \\[1ex]
-     &\wedge& (S'; F; \global.\GINIT \stepto^\ast S'; F; \val~\END)^\ast \\
+     &\wedge& (S'; F; \expr_{\F{g}} \stepto^\ast S'; F; \val~\END)^\ast \\
+     &\wedge& ((S'; F; \expr_{\F{e}} \stepto^\ast S'; F; \reff~\END)^\ast)^n \\
      &\wedge& (\tableaddr = \moduleinst.\MITABLES[\elem.\ETABLE])^\ast \\
      &\wedge& (\memaddr = \moduleinst.\MIMEMS[\data.\DMEM])^\ast \\
      &\wedge& (\funcaddr = \moduleinst.\MIFUNCS[\start.\SFUNC])^?)

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -258,7 +258,6 @@ but within certain :ref:`constraints <exec-invoke-host>` that ensure the integri
 .. index:: ! table instance, table, function address, table type, embedder, element segment
    pair: abstract syntax; table instance
    pair: table; instance
-.. _syntax-funcelem:
 .. _syntax-tableinst:
 
 Table Instances
@@ -340,7 +339,7 @@ It holds a vector of references and their common :ref:`type <syntax-reftype>`.
 .. math::
   \begin{array}{llll}
   \production{(element instance)} & \eleminst &::=&
-    \{ \EITYPE~\reftype, \EIELEM~\vec(\funcelem) \} \\
+    \{ \EITYPE~\reftype, \EIELEM~\vec(\reff) \} \\
   \end{array}
 
 

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -215,9 +215,27 @@ Table Instructions
      \text{table.size}~~x{:}\Ttableidx_I &\Rightarrow& \TABLESIZE~x \\ &&|&
      \text{table.grow}~~x{:}\Ttableidx_I &\Rightarrow& \TABLEGROW~x \\ &&|&
      \text{table.fill}~~x{:}\Ttableidx_I &\Rightarrow& \TABLEFILL~x \\
-     \text{table.copy} &\Rightarrow& \TABLECOPY \\ &&|&
-     \text{table.init}~~x{:}\Telemidx_I &\Rightarrow& \TABLEINIT~x \\ &&|&
+     \text{table.copy}~~x{:}\Ttableidx_I~~y{:}\Ttableidx_I &\Rightarrow& \TABLECOPY~x~y \\ &&|&
+     \text{table.init}~~x{:}\Ttableidx_I~~y{:}\Telemidx_I &\Rightarrow& \TABLEINIT~x~y \\ &&|&
      \text{elem.drop}~~x{:}\Telemidx_I &\Rightarrow& \ELEMDROP~x \\
+   \end{array}
+
+
+Abbreviations
+.............
+
+For backwards compatibility, all :math:`table indices <syntax-tableidx>` may be omitted from table instructions, defaulting to :math:`0`.
+
+.. math::
+   \begin{array}{llclll}
+   \production{instruction} &
+     \text{table.get} &\equiv& \text{table.get}~~\text{0} \\ &&|&
+     \text{table.set} &\equiv& \text{table.set}~~\text{0} \\ &&|&
+     \text{table.size} &\equiv& \text{table.size}~~\text{0} \\ &&|&
+     \text{table.grow} &\equiv& \text{table.grow}~~\text{0} \\ &&|&
+     \text{table.fill} &\equiv& \text{table.fill}~~\text{0} \\ &&|&
+     \text{table.copy} &\equiv& \text{table.copy}~~\text{0}~~\text{0} \\ &&|&
+     \text{table.init}~~x{:}\Telemidx_I &\equiv& \text{table.init}~~\text{0}~~x{:}\Telemidx_I \\ &&|&
    \end{array}
 
 

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -505,7 +505,7 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
    \production{element list} & \Telemlist &::=&
      t{:}\Treftype~~y^\ast{:}\Tvec(\Telemexpr_I) \qquad\Rightarrow\quad ( \ETYPE~t, \EINIT~y^\ast ) \\
    \production{element expression} & \Telemexpr &::=&
-     \text{(}~e{:}\Tinstr~\text{)}
+     \text{(}~\text{item}~~e{:}\Texpr~\text{)}
        \quad\Rightarrow\quad e \\
    \production{table use} & \Ttableuse_I &::=&
      \text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}
@@ -516,13 +516,16 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
 Abbreviations
 .............
 
-As an abbreviation, a single instruction may occur in place of the offset of an active element segment:
+As an abbreviation, a single instruction may occur in place of the offset of an active element segment or as an element expression:
 
 .. math::
    \begin{array}{llcll}
    \production{element offset} &
      \Tinstr &\equiv&
-     \text{(}~\text{offset}~~\Tinstr~\text{)}
+     \text{(}~\text{offset}~~\Tinstr~\text{)} \\
+   \production{element item} &
+     \Tinstr &\equiv&
+     \text{(}~\text{item}~~\Tinstr~\text{)} \\
    \end{array}
 
 Also, the element list may be written as just a sequence of :ref:`function indices <text-funcidx>`:
@@ -534,7 +537,7 @@ Also, the element list may be written as just a sequence of :ref:`function indic
      \text{funcref}~~\Tvec(\text{(}~\text{ref.func}~~\Tfuncidx_I~\text{)})
    \end{array}
 
-Also, a table use can be omitted, defaulting to :math:`\T{0}`.
+A table use can be omitted, defaulting to :math:`\T{0}`.
 Furthermore, for backwards compatibility with earlier versions of WebAssembly, if the table use is omitted, the :math:`\text{func}` keyword can be omitted as well.
 
 .. math::

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -903,7 +903,6 @@
 .. |moduleinst| mathdef:: \xref{exec/runtime}{syntax-moduleinst}{\X{moduleinst}}
 .. |funcinst| mathdef:: \xref{exec/runtime}{syntax-funcinst}{\X{funcinst}}
 .. |tableinst| mathdef:: \xref{exec/runtime}{syntax-tableinst}{\X{tableinst}}
-.. |funcelem| mathdef:: \xref{exec/runtime}{syntax-funcelem}{\X{funcelem}}
 .. |meminst| mathdef:: \xref{exec/runtime}{syntax-meminst}{\X{meminst}}
 .. |globalinst| mathdef:: \xref{exec/runtime}{syntax-globalinst}{\X{globalinst}}
 .. |eleminst| mathdef:: \xref{exec/runtime}{syntax-eleminst}{\X{eleminst}}

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -216,7 +216,7 @@ op:
   br_table <var>+
   return
   call <var>
-  call_indirect <var> <func_type>
+  call_indirect <var>? <func_type>
   drop
   select
   local.get <var>
@@ -224,13 +224,13 @@ op:
   local.tee <var>
   global.get <var>
   global.set <var>
-  table.get <var>
-  table.set <var>
-  table.size <var>
-  table.grow <var>
-  table.fill <var>
-  table.copy
-  table.init <var>
+  table.get <var>?
+  table.set <var>?
+  table.size <var>?
+  table.grow <var>?
+  table.fill <var>?
+  table.copy <var>? <var>?
+  table.init <var>? <var>
   elem.drop <var>
   <val_type>.load((8|16|32)_<sign>)? <offset>? <align>?
   <val_type>.store(8|16|32)? <offset>? <align>?
@@ -263,15 +263,18 @@ global:  ( global <name>? <global_type> <instr>* )
 table:   ( table <name>? <table_type> )
          ( table <name>? ( export <string> ) <...> )                        ;; = (export <string> (table <N>)) (table <name>? <...>)
          ( table <name>? ( import <string> <string> ) <table_type> )        ;; = (import <name>? <string> <string> (table <table_type>))
-         ( table <name>? ( export <string> )* <ref_type> ( elem <var>* ) ) ;; = (table <name>? ( export <string> )* <size> <size> <ref_type>) (elem (i32.const 0) <var>*)
-elem:    ( elem <var>? (offset <instr>* ) <var>* )
-         ( elem <var>? <expr> <var>* )                                      ;; = (elem <var>? (offset <expr>) <var>*)
+         ( table <name>? ( export <string> )* <ref_type> ( elem <var>* ) )  ;; = (table <name>? ( export <string> )* <size> <size> <ref_type>) (elem (i32.const 0) <var>*)
+elem:    ( elem <name>? ( table <var> )? <offset> <ref_type> <item>* )
+         ( elem <name>? ( table <var> )? <offset> func <var>* )             ;; = (elem <name>? ( table <var> )? <offset> funcref (ref.func <var>)*)
+offset:  ( offset <instr>* )
+         <expr>                                                             ;; = ( offset <expr> )
+item:    ( item <instr>* )
+         <expr>                                                             ;; = ( item <expr> )
 memory:  ( memory <name>? <memory_type> )
          ( memory <name>? ( export <string> ) <...> )                       ;; = (export <string> (memory <N>))+ (memory <name>? <...>)
          ( memory <name>? ( import <string> <string> ) <memory_type> )      ;; = (import <name>? <string> <string> (memory <memory_type>))
          ( memory <name>? ( export <string> )* ( data <string>* ) )         ;; = (memory <name>? ( export <string> )* <size> <size>) (data (i32.const 0) <string>*)
-data:    ( data <var>? ( offset <instr>* ) <string>* )
-         ( data <var>? <expr> <string>* )                                   ;; = (data <var>? (offset <expr>) <string>*)
+data:    ( data <name>? ( memory <var> )? <offset> <string>* )
 
 start:   ( start <var> )
 

--- a/interpreter/runtime/table.ml
+++ b/interpreter/runtime/table.ml
@@ -58,26 +58,3 @@ let blit tab offset rs =
   let data = Array.of_list rs in
   try Lib.Array32.blit data 0l tab.content offset (Lib.Array32.length data)
   with Invalid_argument _ -> raise Bounds
-
-(*TODO: remove*)
-let init tab es d s n =
-  let rec loop es d s n =
-    match s, n, es with
-    | s, 0l, _ -> ()
-    | 0l, n, e::es' ->
-      store tab d e;
-      loop es' (Int32.add d 1l) 0l (Int32.sub n 1l)
-    | s, n, _::es' -> loop es' d (Int32.sub s 1l) n
-    | _ -> raise Bounds
-  in loop es d s n
-
-let copy tab d s n =
-  let rec loop d s n dx =
-    if I32.gt_u n 0l then begin
-      store tab d (load tab s);
-      loop (Int32.add d dx) (Int32.add s dx) (Int32.sub n 1l) dx
-    end
-  in (if s < d then
-    loop Int32.(add d (sub n 1l)) Int32.(add s (sub n 1l)) n (-1l)
-  else
-    loop d s n 1l)

--- a/interpreter/runtime/table.mli
+++ b/interpreter/runtime/table.mli
@@ -23,8 +23,3 @@ val grow : table -> size -> ref_ -> unit
 val load : table -> index -> ref_ (* raises Bounds *)
 val store : table -> index -> ref_ -> unit (* raises Type, Bounds *)
 val blit : table -> index -> ref_ list -> unit (* raises Bounds *)
-
-(*TODO: remove*)
-val init :
-  table -> ref_ list -> index -> index -> count -> unit (* raises Bounds *)
-val copy : table -> index -> index -> count -> unit (* raises Bounds *)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -63,7 +63,7 @@ type storeop = Memory.pack_size memop
 (* Expressions *)
 
 type var = int32 Source.phrase
-type literal = Values.num Source.phrase
+type num = Values.num Source.phrase
 type name = int list
 
 type instr = instr' Source.phrase
@@ -105,7 +105,7 @@ and instr' =
   | RefNull                           (* null reference *)
   | RefIsNull                         (* null test *)
   | RefFunc of var                    (* function reference *)
-  | Const of literal                  (* constant *)
+  | Const of num                      (* constant *)
   | Test of testop                    (* numeric test *)
   | Compare of relop                  (* numeric comparison *)
   | Unary of unop                     (* unary numeric operator *)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -265,7 +265,7 @@ let rec instr e =
     | RefNull -> "ref.null", []
     | RefIsNull -> "ref.is_null", []
     | RefFunc x -> "ref.func " ^ var x, []
-    | Const lit -> constop lit ^ " " ^ num lit, []
+    | Const n -> constop n ^ " " ^ num n, []
     | Test op -> testop op, []
     | Compare op -> relop op, []
     | Unary op -> unop op, []

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -251,8 +251,8 @@ let rec instr e =
     | TableSize x -> "table.size " ^ var x, []
     | TableGrow x -> "table.grow " ^ var x, []
     | TableFill x -> "table.fill " ^ var x, []
-    | TableCopy (x, y) -> "table.copy", []  (*TODO*)
-    | TableInit (x, y) -> "table.init " ^ var y, []  (*TODO*)
+    | TableCopy (x, y) -> "table.copy " ^ var x ^ " " ^ var y, []
+    | TableInit (x, y) -> "table.init " ^ var x ^ " " ^ var y, []
     | ElemDrop x -> "elem.drop " ^ var x, []
     | Load op -> loadop op, []
     | Store op -> storeop op, []

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -349,6 +349,7 @@ rule token = parse
   | "elem" { ELEM }
   | "data" { DATA }
   | "offset" { OFFSET }
+  | "item" { ITEM }
   | "import" { IMPORT }
   | "export" { EXPORT }
 

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -36,7 +36,7 @@ let ati i =
 
 (* Literals *)
 
-let literal f s =
+let num f s =
   try f s with Failure _ -> error s.at "constant out of range"
 
 let nanop f nan =
@@ -274,7 +274,7 @@ type_use :
 
 /* Immediates */
 
-literal :
+num :
   | NAT { $1 @@ at () }
   | INT { $1 @@ at () }
   | FLOAT { $1 @@ at () }
@@ -367,7 +367,7 @@ plain_instr :
   | REF_NULL { fun c -> ref_null }
   | REF_IS_NULL { fun c -> ref_is_null }
   | REF_FUNC var { fun c -> ref_func ($2 c func) }
-  | CONST literal { fun c -> fst (literal $1 $2) }
+  | CONST num { fun c -> fst (num $1 $2) }
   | TEST { fun c -> $1 }
   | COMPARE { fun c -> $1 }
   | UNARY { fun c -> $1 }
@@ -972,7 +972,7 @@ meta :
   | LPAR OUTPUT script_var_opt RPAR { Output ($3, None) @@ at () }
 
 const :
-  | LPAR CONST literal RPAR { Values.Num (snd (literal $2 $3)) @@ at () }
+  | LPAR CONST num RPAR { Values.Num (snd (num $2 $3)) @@ at () }
   | LPAR REF_NULL RPAR { Values.Ref Values.NullRef @@ at () }
   | LPAR REF_HOST NAT RPAR { Values.Ref (HostRef (nat32 $3 (ati 3))) @@ at () }
 

--- a/proposals/reference-types/Overview.md
+++ b/proposals/reference-types/Overview.md
@@ -117,6 +117,8 @@ New/extended instructions:
     - and `$x : table t'`
     - and `t' <: funcref`
 
+* In all instructions, table indices can be omitted and default to 0.
+
 Note:
 - In the binary format, space for the additional table indices is already reserved.
 - For backwards compatibility, all table indices may be omitted in the text format, in which case they default to 0 (for `table.copy`, both indices must be either present or absent).

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -8,7 +8,7 @@
 
   ;; Passive
   (elem funcref)
-  (elem funcref (ref.func $f) (ref.func $f) (ref.null) (ref.func $g))
+  (elem funcref (ref.func $f) (item ref.func $f) (item (ref.null)) (ref.func $g))
   (elem func)
   (elem func $f $f $g $g)
 


### PR DESCRIPTION
After rebasing on the bulk proposal, this PR fixes all open todos in interpreter and spec:

- Move to small-step semantics for table instructions [interpreter].
- Add back-compat sugar for table instructions omitting table index [spec/interpreter].
- Add optional `item` keyword to syntactically represent multi-instr element expressions, analogous to syntax for offset. [spec/interpreter]
- Generalise bulk table ops to multiple tables [spec].
- A few smaller todos in spec (segment instantiation, removing funcelems).

Two things still missing after this (modulo new design questions):

- Adding declaration segments (#31) -- I already have a branch for that.
- Actual tests for bulk table ops involving multiple tables, which is in the intersection of the two proposals -- the respective tests are generated, so I could use some help with extending the generators. ;)