### PR TITLE
Rename anyfunc to funcref in js-api tests

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -709,7 +709,7 @@ Immediately after a WebAssembly [=memory.grow=] instruction executes, perform th
 enum TableKind {
   "nullref",
   "anyref",
-  "anyfunc",
+  "funcref",
   // Note: More values may be added in future iterations,
   // e.g., typed function references, typed GC references
 };

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -40,7 +40,7 @@ let spectest = {
   global_i32: 666,
   global_f32: 666,
   global_f64: 666,
-  table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
+  table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'funcref'}),
   memory: new WebAssembly.Memory({initial: 1, maximum: 2})
 };
 

--- a/proposals/bulk-memory-operations/Overview.md
+++ b/proposals/bulk-memory-operations/Overview.md
@@ -218,7 +218,7 @@ of `expr`s instead of function indices.
 | - | - | - | - |
 | flags | `varuint32` | always | Flags for passive and presence of fields below, only values of 0, 1, and 2 are valid |
 | index | `varuint32`? | flags = 2 |  Table index; 0 if the field is not present  |
-| element_type | `elem_type`? | flags = 1 | element type of this segment; `anyfunc` if not present |
+| element_type | `elem_type`? | flags = 1 | element type of this segment; `funcref` if not present |
 | offset | `init_expr`? | flags != 1 | an `i32` initializer expression for offset |
 | count | `varuint32` | always | number of elements |
 | elems | `varuint32*` | flags != 1 | sequence of function indices |
@@ -228,9 +228,9 @@ Another way of looking at it:
 
 | Flags | Active? | index | element_type | offset |
 | - | - | - | - | - |
-| 0 | Active | Always 0 | Always `anyfunc` | Present |
+| 0 | Active | Always 0 | Always `funcref` | Present |
 | 1 | Passive | - | Present | - |
-| 2 | Active | Present | Always `anyfunc` | Present |
+| 2 | Active | Present | Always `funcref` | Present |
 
 An `elem_expr` is like an `init_expr`, but can only contain expressions of the following sequences:
 

--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -79,7 +79,7 @@ function reinitializeRegistry() {
       table: new WebAssembly.Table({
         initial: 10,
         maximum: 20,
-        element: "anyfunc"
+        element: "funcref"
       }),
       memory: new WebAssembly.Memory({ initial: 1, maximum: 2 })
     };

--- a/test/harness/sync_index.js
+++ b/test/harness/sync_index.js
@@ -86,7 +86,7 @@ function reinitializeRegistry() {
         global_i32: 666,
         global_f32: 666,
         global_f64: 666,
-        table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
+        table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'funcref'}),
         memory: new WebAssembly.Memory({initial: 1, maximum: 2})
     };
     let handler = {

--- a/test/js-api/instanceTestFactory.js
+++ b/test/js-api/instanceTestFactory.js
@@ -110,7 +110,7 @@ const instanceTestFactory = [
           "fn": function() {},
           "global": 0,
           "memory": new WebAssembly.Memory({ "initial": 64, maximum: 128 }),
-          "table": new WebAssembly.Table({ "element": "anyfunc", "initial": 64, maximum: 128 }),
+          "table": new WebAssembly.Table({ "element": "funcref", "initial": 64, maximum: 128 }),
         },
         get "module2"() {
           assert_unreached("Should not get modules that are not imported");

--- a/test/js-api/table/constructor.any.js
+++ b/test/js-api/table/constructor.any.js
@@ -25,7 +25,7 @@ test(() => {
 }, "No arguments");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0 };
+  const argument = { "element": "funcref", "initial": 0 };
   assert_throws(new TypeError(), () => WebAssembly.Table(argument));
 }, "Calling");
 
@@ -54,7 +54,7 @@ test(() => {
 }, "Invalid descriptor argument");
 
 test(() => {
-  assert_throws(new TypeError(), () => new WebAssembly.Table({ "element": "anyfunc", "initial": undefined }));
+  assert_throws(new TypeError(), () => new WebAssembly.Table({ "element": "funcref", "initial": undefined }));
 }, "Undefined initial value in descriptor");
 
 test(() => {
@@ -72,32 +72,32 @@ const outOfRangeValues = [
 
 for (const value of outOfRangeValues) {
   test(() => {
-    assert_throws(new TypeError(), () => new WebAssembly.Table({ "element": "anyfunc", "initial": value }));
+    assert_throws(new TypeError(), () => new WebAssembly.Table({ "element": "funcref", "initial": value }));
   }, `Out-of-range initial value in descriptor: ${format_value(value)}`);
 
   test(() => {
-    assert_throws(new TypeError(), () => new WebAssembly.Table({ "element": "anyfunc", "initial": 0, "maximum": value }));
+    assert_throws(new TypeError(), () => new WebAssembly.Table({ "element": "funcref", "initial": 0, "maximum": value }));
   }, `Out-of-range maximum value in descriptor: ${format_value(value)}`);
 }
 
 test(() => {
-  assert_throws(new RangeError(), () => new WebAssembly.Table({ "element": "anyfunc", "initial": 10, "maximum": 9 }));
+  assert_throws(new RangeError(), () => new WebAssembly.Table({ "element": "funcref", "initial": 10, "maximum": 9 }));
 }, "Initial value exceeds maximum");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0 };
+  const argument = { "element": "funcref", "initial": 0 };
   const table = new WebAssembly.Table(argument);
   assert_Table(table, { "length": 0 });
 }, "Basic (zero)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_Table(table, { "length": 5 });
 }, "Basic (non-zero)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0 };
+  const argument = { "element": "funcref", "initial": 0 };
   const table = new WebAssembly.Table(argument, {});
   assert_Table(table, { "length": 0 });
 }, "Stray argument");
@@ -110,7 +110,7 @@ test(() => {
     get(o, x) {
       switch (x) {
       case "element":
-        return "anyfunc";
+        return "funcref";
       case "initial":
       case "maximum":
         return 0;
@@ -126,7 +126,7 @@ test(() => {
 test(() => {
   const table = new WebAssembly.Table({
     "element": {
-      toString() { return "anyfunc"; },
+      toString() { return "funcref"; },
     },
     "initial": 1,
   });
@@ -162,7 +162,7 @@ test(() => {
       return {
         toString() {
           order.push("element toString");
-          return "anyfunc";
+          return "funcref";
         },
       };
     },

--- a/test/js-api/table/get-set.any.js
+++ b/test/js-api/table/get-set.any.js
@@ -22,7 +22,7 @@ setup(() => {
 });
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_throws(new TypeError(), () => table.get());
 }, "Missing arguments: get");
@@ -53,7 +53,7 @@ test(t => {
 }, "Branding: get");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_throws(new TypeError(), () => table.set());
   assert_throws(new TypeError(), () => table.set(0));
@@ -85,7 +85,7 @@ test(t => {
 }, "Branding: set");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null, null, null, null, null]);
 
@@ -102,7 +102,7 @@ test(() => {
 }, "Basic");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null, null, null, null, null]);
 
@@ -120,7 +120,7 @@ test(() => {
 }, "Growing");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null, null, null, null, null]);
 
@@ -134,7 +134,7 @@ test(() => {
 }, "Setting out-of-bounds");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 1 };
+  const argument = { "element": "funcref", "initial": 1 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null]);
 
@@ -156,7 +156,7 @@ test(() => {
 }, "Setting non-function");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 1 };
+  const argument = { "element": "funcref", "initial": 1 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null]);
 
@@ -166,7 +166,7 @@ test(() => {
 }, "Setting non-wasm function");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 1 };
+  const argument = { "element": "funcref", "initial": 1 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null]);
 
@@ -189,20 +189,20 @@ const outOfRangeValues = [
 
 for (const value of outOfRangeValues) {
   test(() => {
-    const argument = { "element": "anyfunc", "initial": 1 };
+    const argument = { "element": "funcref", "initial": 1 };
     const table = new WebAssembly.Table(argument);
     assert_throws(new TypeError(), () => table.get(value));
   }, `Getting out-of-range argument: ${format_value(value)}`);
 
   test(() => {
-    const argument = { "element": "anyfunc", "initial": 1 };
+    const argument = { "element": "funcref", "initial": 1 };
     const table = new WebAssembly.Table(argument);
     assert_throws(new TypeError(), () => table.set(value, null));
   }, `Setting out-of-range argument: ${format_value(value)}`);
 }
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 1 };
+  const argument = { "element": "funcref", "initial": 1 };
   const table = new WebAssembly.Table(argument);
   let called = 0;
   const value = {
@@ -217,7 +217,7 @@ test(() => {
 
 test(() => {
   const {fn} = functions;
-  const argument = { "element": "anyfunc", "initial": 1 };
+  const argument = { "element": "funcref", "initial": 1 };
   const table = new WebAssembly.Table(argument);
 
   assert_equals(table.get(0, {}), null);

--- a/test/js-api/table/grow.any.js
+++ b/test/js-api/table/grow.any.js
@@ -6,7 +6,7 @@ function nulls(n) {
 }
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_throws(new TypeError(), () => table.grow());
 }, "Missing arguments");
@@ -37,7 +37,7 @@ test(t => {
 }, "Branding");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(5), "before");
 
@@ -47,7 +47,7 @@ test(() => {
 }, "Basic");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 3, "maximum": 5 };
+  const argument = { "element": "funcref", "initial": 3, "maximum": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(3), "before");
 
@@ -57,7 +57,7 @@ test(() => {
 }, "Reached maximum");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 2, "maximum": 5 };
+  const argument = { "element": "funcref", "initial": 2, "maximum": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(2), "before");
 
@@ -79,14 +79,14 @@ const outOfRangeValues = [
 
 for (const value of outOfRangeValues) {
   test(() => {
-    const argument = { "element": "anyfunc", "initial": 1 };
+    const argument = { "element": "funcref", "initial": 1 };
     const table = new WebAssembly.Table(argument);
     assert_throws(new TypeError(), () => table.grow(value));
   }, `Out-of-range argument: ${format_value(value)}`);
 }
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 5 };
+  const argument = { "element": "funcref", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(5), "before");
 

--- a/test/js-api/table/length.any.js
+++ b/test/js-api/table/length.any.js
@@ -27,7 +27,7 @@ test(() => {
 }, "Branding");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 2 };
+  const argument = { "element": "funcref", "initial": 2 };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 2, "Initial length");
 
@@ -41,7 +41,7 @@ test(() => {
 }, "Stray argument");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 2 };
+  const argument = { "element": "funcref", "initial": 2 };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 2, "Initial length");
   table.length = 4;
@@ -49,7 +49,7 @@ test(() => {
 }, "Setting (sloppy mode)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 2 };
+  const argument = { "element": "funcref", "initial": 2 };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 2, "Initial length");
   assert_throws(new TypeError(), () => {

--- a/test/js-api/table/toString.any.js
+++ b/test/js-api/table/toString.any.js
@@ -1,7 +1,7 @@
 // META: global=jsshell
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0 };
+  const argument = { "element": "funcref", "initial": 0 };
   const table = new WebAssembly.Table(argument);
   assert_class_string(table, "WebAssembly.Table");
 }, "Object.prototype.toString on an Table");

--- a/test/meta/generate_memory_init.js
+++ b/test/meta/generate_memory_init.js
@@ -219,7 +219,7 @@ print(
 (assert_trap (invoke "test") "out of bounds")
 `);
 
-// invalid argument types.  TODO: can add anyfunc etc here.
+// invalid argument types.  TODO: can add funcref etc here.
 {
     const tys  = ['i32', 'f32', 'i64', 'f64'];
 


### PR DESCRIPTION
The string `anyfunc` still occurred in js-api tests. This PR replaces all these occurrences by `funcref`.