### PR TITLE
Update JS test harnesses to match changes to interpreter harness

### DIFF
--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -52,6 +52,22 @@ const EXPECT_INVALID = false;
 
 /* DATA **********************************************************************/
 
+let hostrefs = {};
+let hostsym = Symbol("hostref");
+function hostref(s) {
+  if (! (s in hostrefs)) hostrefs[s] = {[hostsym]: s};
+  return hostrefs[s];
+}
+function is_hostref(x) {
+  return (x !== null && hostsym in x) ? 1 : 0;
+}
+function is_funcref(x) {
+  return typeof x === "function" ? 1 : 0;
+}
+function eq_ref(x, y) {
+  return x === y ? 1 : 0;
+}
+
 // Default imports.
 var registry = {};
 
@@ -67,6 +83,10 @@ function reinitializeRegistry() {
 
   chain = chain.then(_ => {
     let spectest = {
+      hostref: hostref,
+      is_hostref: is_hostref,
+      is_funcref: is_funcref,
+      eq_ref: eq_ref,
       print: console.log.bind(console),
       print_i32: console.log.bind(console),
       print_i32_f32: console.log.bind(console),
@@ -180,9 +200,9 @@ function instance(bytes, imports, valid = true) {
   return chain;
 }
 
-function exports(name, instance) {
+function exports(instance) {
   return instance.then(inst => {
-    return { [name]: inst.exports };
+    return { module: inst.exports, spectest: registry.spectest };
   });
 }
 
@@ -243,7 +263,23 @@ function assert_return(action, expected) {
     .then(
       values => {
         uniqueTest(_ => {
-          assert_equals(values[0], expected, loc);
+          let actual = values[0];
+          switch (expected) {
+          case "nan:canonical":
+          case "nan:arithmetic":
+              // Note that JS can't reliably distinguish different NaN values,
+              // so there's no good way to test that it's a canonical NaN.
+              assert_true(Number.isNaN(actual), `expected NaN, observed ${actual}.`);
+              return;
+          case "ref.func":
+              assert_true(typeof actual === "function", `expected Wasm function, got ${actual}`);
+              return;
+          case "ref.any":
+              assert_true(actual !== null, `expected Wasm reference, got ${actual}`);
+              return;
+          default:
+              assert_equals(actual, expected);
+          }
         }, test);
       },
       error => {

--- a/test/harness/sync_index.js
+++ b/test/harness/sync_index.js
@@ -66,6 +66,22 @@ const EXPECT_INVALID = false;
 
 /* DATA **********************************************************************/
 
+let hostrefs = {};
+let hostsym = Symbol("hostref");
+function hostref(s) {
+  if (! (s in hostrefs)) hostrefs[s] = {[hostsym]: s};
+  return hostrefs[s];
+}
+function is_hostref(x) {
+  return (x !== null && hostsym in x) ? 1 : 0;
+}
+function is_funcref(x) {
+  return typeof x === "function" ? 1 : 0;
+}
+function eq_ref(x, y) {
+  return x === y ? 1 : 0;
+}
+
 let $$;
 
 // Default imports.
@@ -77,6 +93,10 @@ function reinitializeRegistry() {
         return;
 
     let spectest = {
+        hostref: hostref,
+        is_hostref: is_hostref,
+        is_funcref: is_funcref,
+        eq_ref: eq_ref,
         print: console.log.bind(console),
         print_i32: console.log.bind(console),
         print_i32_f32: console.log.bind(console),
@@ -227,13 +247,13 @@ function get(instance, name) {
     return ValueResult(instance.value.exports[name]);
 }
 
-function exports(name, instance) {
+function exports(instance) {
     _assert(instance instanceof Result);
 
     if (instance.isError())
         return instance;
 
-    return ValueResult({ [name]: instance.value.exports });
+    return ValueResult({ module: instance.value.exports, spectest: registry.spectest });
 }
 
 function run(action) {
@@ -319,11 +339,26 @@ function assert_return(action, expected) {
 
     uniqueTest(() => {
         assert_true(!result.isError(), `expected success result, got: ${result.value}.`);
-        if (!result.isError()) {
-            assert_equals(result.value, expected);
-        };
+        let actual = result.value;
+        switch (expected) {
+        case "nan:canonical":
+        case "nan:arithmetic":
+            // Note that JS can't reliably distinguish different NaN values,
+            // so there's no good way to test that it's a canonical NaN.
+            assert_true(Number.isNaN(actual), `expected NaN, observed ${actual}.`);
+            return;
+        case "ref.func":
+            assert_true(typeof actual === "function", `expected Wasm function, got ${actual}`);
+            return;
+        case "ref.any":
+            assert_true(actual !== null, `expected Wasm reference, got ${actual}`);
+            return;
+        default:
+            assert_equals(actual, expected);
+        }
+
     }, "A wast module that must return a particular value.");
-};
+}
 
 function assert_return_nan(action) {
     let result = action();


### PR DESCRIPTION
script/js.ml changed and started emitting different JS harness code.
This commit updates sync_index.js and async_index.js to match.