### PR TITLE
[tests] Delete leftover harness function

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -33,7 +33,6 @@ let spectest = {
   externref: externref,
   is_externref: is_externref,
   is_funcref: is_funcref,
-  eq_ref: eq_ref,
   print: console.log.bind(console),
   print_i32: console.log.bind(console),
   print_i32_f32: console.log.bind(console),


### PR DESCRIPTION
In the generated test files the generic imports contained a function that does not exist anymore. This caused all tests to fail. This PR removes the function from the imports.