### PR TITLE
Re-add test that fails with a bottom type

### DIFF
--- a/test/core/unreached-invalid.wast
+++ b/test/core/unreached-invalid.wast
@@ -537,6 +537,21 @@
 )
 
 (assert_invalid
+  (module (func $type-br_table-label-num-vs-label-num-after-unreachable
+    (block (result f64)
+      (block (result f32)
+        (unreachable)
+        (br_table 0 1 1 (i32.const 1))
+      )
+      (drop)
+      (f64.const 0)
+    )
+    (drop)
+  ))
+  "type mismatch"
+)
+
+(assert_invalid
   (module (func $type-block-value-nested-unreachable-num-vs-void
     (block (i32.const 3) (block (unreachable)))
   ))


### PR DESCRIPTION
The original commit to add a bottom type removed this test as it
would now unexpectedly validate. Now that a bottom type is removed
it would be good to keep it.