### PR TITLE
Fix links to `table.fill`'s validation and execution in appendix

### DIFF
--- a/document/core/appendix/index-instructions.rst
+++ b/document/core/appendix/index-instructions.rst
@@ -265,7 +265,7 @@ Instruction                                Binary Opcode              Type      
 :math:`\TABLECOPY`                         :math:`\hex{FC}~\hex{0E}`  :math:`[\I32~\I32~\I32] \to []`                :ref:`validation <valid-table.copy>`      :ref:`execution <exec-table.copy>`
 :math:`\TABLEGROW`                         :math:`\hex{FC}~\hex{0F}`  :math:`[t~\I32] \to []`                        :ref:`validation <valid-table.grow>`      :ref:`execution <exec-table.grow>`
 :math:`\TABLESIZE`                         :math:`\hex{FC}~\hex{10}`  :math:`[] \to []`                              :ref:`validation <valid-table.size>`      :ref:`execution <exec-table.size>`
-:math:`\TABLEFILL`                         :math:`\hex{FC}~\hex{11}`  :math:`[\I32~t~\I32] \to []`                   :ref:`validation <valid-table.init>`      :ref:`execution <exec-table.init>`
+:math:`\TABLEFILL`                         :math:`\hex{FC}~\hex{11}`  :math:`[\I32~t~\I32] \to []`                   :ref:`validation <valid-table.fill>`      :ref:`execution <exec-table.fill>`
 (reserved)                                 :math:`\hex{FD}`                                                  
 (reserved)                                 :math:`\hex{FE}`                                                  
 (reserved)                                 :math:`\hex{FF}`                                                  


### PR DESCRIPTION
@rossberg, could you please take a look? Thanks