### PR TITLE
Fix decription of ref.func

### DIFF
--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -191,7 +191,7 @@ Instructions in this group are concerned with accessing :ref:`references <syntax
      \REFFUNC~\funcidx \\
    \end{array}
 
-These instruction produce a null value, check for a null value, or compare two references, respectively.
+These instruction produce a null value, check for a null value, or produce a reference to a given function, respectively.
 
 
 .. index:: ! parametric instruction, value type


### PR DESCRIPTION
The incorrect description is a leftover from the original proposal,
which specified a ref.eq instruction:
https://github.com/WebAssembly/reference-types/commit/1f29a8ee7af86c45769fd130c67e09ad0f9b197f#diff-90422c6925e039f03d4bcf0359947b08R187-R190