### PR TITLE
[test] Uniform failure strings

### DIFF
--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -169,11 +169,11 @@
 (invoke "drop_passive")
 (invoke "drop_passive")
 (assert_return (invoke "init_passive" (i32.const 0)))
-(assert_trap (invoke "init_passive" (i32.const 1)) "out of bounds")
+(assert_trap (invoke "init_passive" (i32.const 1)) "out of bounds memory access")
 (invoke "init_passive" (i32.const 0))
 (invoke "drop_active")
 (assert_return (invoke "init_active" (i32.const 0)))
-(assert_trap (invoke "init_active" (i32.const 1)) "out of bounds")
+(assert_trap (invoke "init_active" (i32.const 1)) "out of bounds memory access")
 (invoke "init_active" (i32.const 0))
 
 ;; Test that the data segment index is properly encoded as an unsigned (not
@@ -262,11 +262,11 @@
 (invoke "drop_passive")
 (invoke "drop_passive")
 (assert_return (invoke "init_passive" (i32.const 0)))
-(assert_trap (invoke "init_passive" (i32.const 1)) "out of bounds")
+(assert_trap (invoke "init_passive" (i32.const 1)) "out of bounds table access")
 (invoke "init_passive" (i32.const 0))
 (invoke "drop_active")
 (assert_return (invoke "init_active" (i32.const 0)))
-(assert_trap (invoke "init_active" (i32.const 1)) "out of bounds")
+(assert_trap (invoke "init_active" (i32.const 1)) "out of bounds table access")
 (invoke "init_active" (i32.const 0))
 
 ;; Test that the elem segment index is properly encoded as an unsigned (not
@@ -346,6 +346,6 @@
 
 ;; Fail on out-of-bounds when copying 0 elements outside of table.
 (assert_trap (invoke "copy" (i32.const 11) (i32.const 0) (i32.const 0))
-  "out of bounds")
+  "out of bounds table access")
 (assert_trap (invoke "copy" (i32.const 0) (i32.const 11) (i32.const 0))
-  "out of bounds")
+  "out of bounds table access")

--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -175,7 +175,7 @@
     (memory 0)
     (data (i32.const 0) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 (assert_trap
@@ -183,7 +183,7 @@
     (memory 0 0)
     (data (i32.const 0) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 (assert_trap
@@ -191,21 +191,21 @@
     (memory 0 1)
     (data (i32.const 0) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 (assert_trap
   (module
     (memory 0)
     (data (i32.const 1))
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 (assert_trap
   (module
     (memory 0 1)
     (data (i32.const 1))
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 ;; This seems to cause a time-out on Travis.
@@ -223,7 +223,7 @@
     (memory 0)
     (data (global.get 0) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 (assert_trap
@@ -231,14 +231,14 @@
     (memory 1 2)
     (data (i32.const 0x1_0000) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 (assert_trap
   (module
     (import "spectest" "memory" (memory 1))
     (data (i32.const 0x1_0000) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 (assert_trap
@@ -246,7 +246,7 @@
     (memory 2)
     (data (i32.const 0x2_0000) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 (assert_trap
@@ -254,7 +254,7 @@
     (memory 2 3)
     (data (i32.const 0x2_0000) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 (assert_trap
@@ -262,14 +262,14 @@
     (memory 1)
     (data (i32.const -1) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 (assert_trap
   (module
     (import "spectest" "memory" (memory 1))
     (data (i32.const -1) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 (assert_trap
@@ -277,14 +277,14 @@
     (memory 2)
     (data (i32.const -100) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 (assert_trap
   (module
     (import "spectest" "memory" (memory 1))
     (data (i32.const -100) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 ;; Data without memory

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -211,7 +211,7 @@
     (func $f)
     (elem (i32.const 0) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 
 (assert_trap
@@ -220,7 +220,7 @@
     (func $f)
     (elem (i32.const 0) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 
 (assert_trap
@@ -229,7 +229,7 @@
     (func $f)
     (elem (i32.const 0) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 
 (assert_trap
@@ -237,7 +237,7 @@
     (table 0 funcref)
     (elem (i32.const 1))
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 (assert_trap
   (module
@@ -245,7 +245,7 @@
     (func $f)
     (elem (i32.const 10) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 (assert_trap
   (module
@@ -253,7 +253,7 @@
     (func $f)
     (elem (i32.const 10) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 
 (assert_trap
@@ -262,7 +262,7 @@
     (func $f)
     (elem (i32.const 10) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 (assert_trap
   (module
@@ -270,7 +270,7 @@
     (func $f)
     (elem (i32.const 10) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 
 (assert_trap
@@ -279,7 +279,7 @@
     (func $f)
     (elem (i32.const -1) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 (assert_trap
   (module
@@ -287,7 +287,7 @@
     (func $f)
     (elem (i32.const -1) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 
 (assert_trap
@@ -296,7 +296,7 @@
     (func $f)
     (elem (i32.const -10) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 (assert_trap
   (module
@@ -304,7 +304,7 @@
     (func $f)
     (elem (i32.const -10) $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 
 ;; Implicitly dropped elements
@@ -317,7 +317,7 @@
     (table.init $e (i32.const 0) (i32.const 0) (i32.const 1))
   )
 )
-(assert_trap (invoke "init") "out of bounds")
+(assert_trap (invoke "init") "out of bounds table access")
 
 (module
   (table 10 funcref)
@@ -327,7 +327,7 @@
     (table.init $e (i32.const 0) (i32.const 0) (i32.const 1))
   )
 )
-(assert_trap (invoke "init") "out of bounds")
+(assert_trap (invoke "init") "out of bounds table access")
 
 ;; Element without table
 

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -170,23 +170,23 @@
 (assert_return (invoke $Nt "call" (i32.const 2)) (i32.const 5))
 (assert_return (invoke $Nt "call Mt.call" (i32.const 2)) (i32.const 4))
 
-(assert_trap (invoke $Mt "call" (i32.const 1)) "uninitialized")
-(assert_trap (invoke $Nt "Mt.call" (i32.const 1)) "uninitialized")
+(assert_trap (invoke $Mt "call" (i32.const 1)) "uninitialized element")
+(assert_trap (invoke $Nt "Mt.call" (i32.const 1)) "uninitialized element")
 (assert_return (invoke $Nt "call" (i32.const 1)) (i32.const 5))
-(assert_trap (invoke $Nt "call Mt.call" (i32.const 1)) "uninitialized")
+(assert_trap (invoke $Nt "call Mt.call" (i32.const 1)) "uninitialized element")
 
-(assert_trap (invoke $Mt "call" (i32.const 0)) "uninitialized")
-(assert_trap (invoke $Nt "Mt.call" (i32.const 0)) "uninitialized")
+(assert_trap (invoke $Mt "call" (i32.const 0)) "uninitialized element")
+(assert_trap (invoke $Nt "Mt.call" (i32.const 0)) "uninitialized element")
 (assert_return (invoke $Nt "call" (i32.const 0)) (i32.const 5))
-(assert_trap (invoke $Nt "call Mt.call" (i32.const 0)) "uninitialized")
+(assert_trap (invoke $Nt "call Mt.call" (i32.const 0)) "uninitialized element")
 
-(assert_trap (invoke $Mt "call" (i32.const 20)) "undefined")
-(assert_trap (invoke $Nt "Mt.call" (i32.const 20)) "undefined")
-(assert_trap (invoke $Nt "call" (i32.const 7)) "undefined")
-(assert_trap (invoke $Nt "call Mt.call" (i32.const 20)) "undefined")
+(assert_trap (invoke $Mt "call" (i32.const 20)) "undefined element")
+(assert_trap (invoke $Nt "Mt.call" (i32.const 20)) "undefined element")
+(assert_trap (invoke $Nt "call" (i32.const 7)) "undefined element")
+(assert_trap (invoke $Nt "call Mt.call" (i32.const 20)) "undefined element")
 
 (assert_return (invoke $Nt "call" (i32.const 3)) (i32.const -4))
-(assert_trap (invoke $Nt "call" (i32.const 4)) "indirect call")
+(assert_trap (invoke $Nt "call" (i32.const 4)) "indirect call type mismatch")
 
 (module $Ot
   (type (func (result i32)))
@@ -218,13 +218,13 @@
 (assert_return (invoke $Nt "call Mt.call" (i32.const 1)) (i32.const 6))
 (assert_return (invoke $Ot "call" (i32.const 1)) (i32.const 6))
 
-(assert_trap (invoke $Mt "call" (i32.const 0)) "uninitialized")
-(assert_trap (invoke $Nt "Mt.call" (i32.const 0)) "uninitialized")
+(assert_trap (invoke $Mt "call" (i32.const 0)) "uninitialized element")
+(assert_trap (invoke $Nt "Mt.call" (i32.const 0)) "uninitialized element")
 (assert_return (invoke $Nt "call" (i32.const 0)) (i32.const 5))
-(assert_trap (invoke $Nt "call Mt.call" (i32.const 0)) "uninitialized")
-(assert_trap (invoke $Ot "call" (i32.const 0)) "uninitialized")
+(assert_trap (invoke $Nt "call Mt.call" (i32.const 0)) "uninitialized element")
+(assert_trap (invoke $Ot "call" (i32.const 0)) "uninitialized element")
 
-(assert_trap (invoke $Ot "call" (i32.const 20)) "undefined")
+(assert_trap (invoke $Ot "call" (i32.const 20)) "undefined element")
 
 (module
   (table (import "Mt" "tab") 0 funcref)
@@ -246,7 +246,7 @@
     (elem (i32.const 10) $f)
     (func $f)
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 
 (assert_unlinkable
@@ -259,7 +259,7 @@
   )
   "unknown import"
 )
-(assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized")
+(assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized element")
 
 ;; Unlike in the v1 spec, active element segments stored before an
 ;; out-of-bounds access persist after the instantiation failure.
@@ -270,10 +270,10 @@
     (elem (i32.const 7) $f)
     (elem (i32.const 8) $f $f $f $f $f)  ;; (partially) out of bounds
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 (assert_return (invoke $Mt "call" (i32.const 7)) (i32.const 0))
-(assert_trap (invoke $Mt "call" (i32.const 8)) "uninitialized")
+(assert_trap (invoke $Mt "call" (i32.const 8)) "uninitialized element")
 
 (assert_trap
   (module
@@ -283,7 +283,7 @@
     (memory 1)
     (data (i32.const 0x10000) "d")  ;; out of bounds
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 (assert_return (invoke $Mt "call" (i32.const 7)) (i32.const 0))
 
@@ -361,7 +361,7 @@
     (memory (import "Mm" "mem") 0)
     (data (i32.const 0x10000) "a")
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 
 (module $Pm
@@ -401,7 +401,7 @@
     (data (i32.const 0) "abc")
     (data (i32.const 327670) "zzzzzzzzzzzzzzzzzz") ;; (partially) out of bounds
   )
-  "out of bounds"
+  "out of bounds memory access"
 )
 (assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 97))
 (assert_return (invoke $Mm "load" (i32.const 327670)) (i32.const 0))
@@ -414,7 +414,7 @@
     (func)
     (elem (i32.const 0) 0)  ;; out of bounds
   )
-  "out of bounds"
+  "out of bounds table access"
 )
 (assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 97))
 

--- a/test/core/memory_copy.wast
+++ b/test/core/memory_copy.wast
@@ -348,7 +348,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 65516) (i32.const 0) (i32.const 40))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 1)) (i32.const 1))
@@ -709,7 +709,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 65515) (i32.const 0) (i32.const 39))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 1)) (i32.const 1))
@@ -1071,7 +1071,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 0) (i32.const 65516) (i32.const 40))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -1432,7 +1432,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 0) (i32.const 65515) (i32.const 39))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -1794,7 +1794,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 65516) (i32.const 65486) (i32.const 40))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -2155,7 +2155,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 65486) (i32.const 65516) (i32.const 40))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -2516,7 +2516,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 65516) (i32.const 65506) (i32.const 40))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -2877,7 +2877,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 65506) (i32.const 65516) (i32.const 40))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -3238,7 +3238,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 65516) (i32.const 65516) (i32.const 40))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -3599,7 +3599,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 0) (i32.const 65516) (i32.const 4294963200))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -3960,7 +3960,7 @@
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const 65516) (i32.const 61440) (i32.const 4294967040))
-             "out of bounds")
+             "out of bounds memory access")
 
 (assert_return (invoke "load8_u" (i32.const 198)) (i32.const 0))
 (assert_return (invoke "load8_u" (i32.const 397)) (i32.const 0))
@@ -4816,25 +4816,25 @@
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0xFF00) (i32.const 0x8000) (i32.const 257))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0xFFFFFF00) (i32.const 0x4000) (i32.const 257))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0x8000) (i32.const 0xFF00) (i32.const 257))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
  (memory 1 1)
  (func (export "test")
    (memory.copy (i32.const 0x4000) (i32.const 0xFFFFFF00) (i32.const 257))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1 1)
@@ -4870,7 +4870,7 @@
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0x20000) (i32.const 0x7000) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1 1)
@@ -4882,7 +4882,7 @@
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0x9000) (i32.const 0x20000) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1 1)
@@ -4894,7 +4894,7 @@
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0x20000) (i32.const 0x20000) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1 1)

--- a/test/core/memory_fill.wast
+++ b/test/core/memory_fill.wast
@@ -115,7 +115,7 @@
 
   (func (export "test")
     (memory.fill (i32.const 0x20000) (i32.const 0x55) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1 1)
@@ -636,7 +636,7 @@
     (memory.fill (local.get $offs) (local.get $val) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 65280) (i32.const 37) (i32.const 512))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))
@@ -658,7 +658,7 @@
     (memory.fill (local.get $offs) (local.get $val) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 65279) (i32.const 37) (i32.const 514))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))
@@ -680,7 +680,7 @@
     (memory.fill (local.get $offs) (local.get $val) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 65279) (i32.const 37) (i32.const 4294967295))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))

--- a/test/core/memory_init.wast
+++ b/test/core/memory_init.wast
@@ -214,14 +214,14 @@
   (func (export "test")
     (data.drop 0)
     (memory.init 0 (i32.const 1234) (i32.const 1) (i32.const 1))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
    (memory 1)
    (data (i32.const 0) "\37")
    (func (export "test")
      (memory.init 0 (i32.const 1234) (i32.const 1) (i32.const 1))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (assert_invalid
   (module
@@ -250,28 +250,28 @@
     (data "\37")
   (func (export "test")
     (memory.init 0 (i32.const 1234) (i32.const 0) (i32.const 5))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1)
     (data "\37")
   (func (export "test")
     (memory.init 0 (i32.const 1234) (i32.const 2) (i32.const 3))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1)
     (data "\37")
   (func (export "test")
     (memory.init 0 (i32.const 0xFFFE) (i32.const 1) (i32.const 3))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1)
     (data "\37")
   (func (export "test")
     (memory.init 0 (i32.const 1234) (i32.const 4) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1)
@@ -285,7 +285,7 @@
     (data "\37")
   (func (export "test")
     (memory.init 0 (i32.const 0x10001) (i32.const 0) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory 1)
@@ -306,7 +306,7 @@
     (data "\37")
   (func (export "test")
     (memory.init 0 (i32.const 0x10001) (i32.const 4) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 
 (assert_invalid
   (module
@@ -831,7 +831,7 @@
     (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 65528) (i32.const 16))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))
@@ -854,7 +854,7 @@
     (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 65527) (i32.const 16))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))
@@ -877,7 +877,7 @@
     (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 65472) (i32.const 30))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))
@@ -900,7 +900,7 @@
     (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 65473) (i32.const 31))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))
@@ -923,7 +923,7 @@
     (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 65528) (i32.const 4294967040))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))
@@ -946,7 +946,7 @@
     (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 0) (i32.const 4294967292))
-              "out of bounds")
+              "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i32.const 0) (i32.const 1) (i32.const 0))
                (i32.const -1))

--- a/test/core/table_copy.wast
+++ b/test/core/table_copy.wast
@@ -1691,7 +1691,7 @@
     (table.copy $t0 $t0 (i32.const 28) (i32.const 1) (i32.const 3))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -1716,7 +1716,7 @@
     (table.copy $t0 $t0 (i32.const 0xFFFFFFFE) (i32.const 1) (i32.const 2))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -1741,7 +1741,7 @@
     (table.copy $t0 $t0 (i32.const 15) (i32.const 25) (i32.const 6))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -1766,7 +1766,7 @@
     (table.copy $t0 $t0 (i32.const 15) (i32.const 0xFFFFFFFE) (i32.const 2))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -1841,7 +1841,7 @@
     (table.copy $t0 $t0 (i32.const 31) (i32.const 15) (i32.const 0))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -1891,7 +1891,7 @@
     (table.copy $t0 $t0 (i32.const 15) (i32.const 31) (i32.const 0))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -1941,7 +1941,7 @@
     (table.copy $t0 $t0 (i32.const 31) (i32.const 31) (i32.const 0))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -1966,7 +1966,7 @@
     (table.copy $t1 $t0 (i32.const 28) (i32.const 1) (i32.const 3))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -1991,7 +1991,7 @@
     (table.copy $t1 $t0 (i32.const 0xFFFFFFFE) (i32.const 1) (i32.const 2))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -2016,7 +2016,7 @@
     (table.copy $t1 $t0 (i32.const 15) (i32.const 25) (i32.const 6))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -2041,7 +2041,7 @@
     (table.copy $t1 $t0 (i32.const 15) (i32.const 0xFFFFFFFE) (i32.const 2))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -2116,7 +2116,7 @@
     (table.copy $t1 $t0 (i32.const 31) (i32.const 15) (i32.const 0))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -2166,7 +2166,7 @@
     (table.copy $t1 $t0 (i32.const 15) (i32.const 31) (i32.const 0))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -2216,7 +2216,7 @@
     (table.copy $t1 $t0 (i32.const 31) (i32.const 31) (i32.const 0))
     ))
 
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (type (func (result i32)))
@@ -2245,7 +2245,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 24) (i32.const 0) (i32.const 16))
-             "out of bounds")
+             "out of bounds table access")
 (assert_return (invoke "test" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "test" (i32.const 1)) (i32.const 1))
 (assert_return (invoke "test" (i32.const 2)) (i32.const 2))
@@ -2306,7 +2306,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 23) (i32.const 0) (i32.const 15))
-             "out of bounds")
+             "out of bounds table access")
 (assert_return (invoke "test" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "test" (i32.const 1)) (i32.const 1))
 (assert_return (invoke "test" (i32.const 2)) (i32.const 2))
@@ -2367,7 +2367,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 0) (i32.const 24) (i32.const 16))
-             "out of bounds")
+             "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2428,7 +2428,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 0) (i32.const 23) (i32.const 15))
-             "out of bounds")
+             "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2489,7 +2489,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 24) (i32.const 11) (i32.const 16))
-             "out of bounds")
+             "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2550,7 +2550,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 11) (i32.const 24) (i32.const 16))
-             "out of bounds")
+             "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2611,7 +2611,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 24) (i32.const 21) (i32.const 16))
-             "out of bounds")
+             "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2672,7 +2672,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 21) (i32.const 24) (i32.const 16))
-             "out of bounds")
+             "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2733,7 +2733,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 21) (i32.const 21) (i32.const 16))
-             "out of bounds")
+             "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2794,7 +2794,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 0) (i32.const 112) (i32.const 4294967264))
-             "out of bounds")
+             "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2951,7 +2951,7 @@
     (table.copy (local.get $targetOffs) (local.get $srcOffs) (local.get $len))))
 
 (assert_trap (invoke "run" (i32.const 112) (i32.const 0) (i32.const 4294967264))
-             "out of bounds")
+             "out of bounds table access")
 (assert_return (invoke "test" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "test" (i32.const 1)) (i32.const 1))
 (assert_return (invoke "test" (i32.const 2)) (i32.const 2))

--- a/test/core/table_fill.wast
+++ b/test/core/table_fill.wast
@@ -48,7 +48,7 @@
 
 (assert_trap
   (invoke "fill" (i32.const 8) (ref.extern 6) (i32.const 3))
-  "out of bounds"
+  "out of bounds table access"
 )
 (assert_return (invoke "get" (i32.const 7)) (ref.null extern))
 (assert_return (invoke "get" (i32.const 8)) (ref.extern 4))
@@ -56,12 +56,12 @@
 
 (assert_trap
   (invoke "fill" (i32.const 11) (ref.null extern) (i32.const 0))
-  "out of bounds"
+  "out of bounds table access"
 )
 
 (assert_trap
   (invoke "fill" (i32.const 11) (ref.null extern) (i32.const 10))
-  "out of bounds"
+  "out of bounds table access"
 )
 
 

--- a/test/core/table_get.wast
+++ b/test/core/table_get.wast
@@ -30,10 +30,10 @@
 (assert_return (invoke "is_null-funcref" (i32.const 1)) (i32.const 0))
 (assert_return (invoke "is_null-funcref" (i32.const 2)) (i32.const 0))
 
-(assert_trap (invoke "get-externref" (i32.const 2)) "out of bounds")
-(assert_trap (invoke "get-funcref" (i32.const 3)) "out of bounds")
-(assert_trap (invoke "get-externref" (i32.const -1)) "out of bounds")
-(assert_trap (invoke "get-funcref" (i32.const -1)) "out of bounds")
+(assert_trap (invoke "get-externref" (i32.const 2)) "out of bounds table access")
+(assert_trap (invoke "get-funcref" (i32.const 3)) "out of bounds table access")
+(assert_trap (invoke "get-externref" (i32.const -1)) "out of bounds table access")
+(assert_trap (invoke "get-funcref" (i32.const -1)) "out of bounds table access")
 
 
 ;; Type errors

--- a/test/core/table_init.wast
+++ b/test/core/table_init.wast
@@ -450,7 +450,7 @@
   (func (export "test")
     (table.init 2 (i32.const 12) (i32.const 1) (i32.const 1))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -522,7 +522,7 @@
   (func (export "test")
     (elem.drop 1)
     (table.init 1 (i32.const 12) (i32.const 1) (i32.const 1))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -546,7 +546,7 @@
   (func (export "test")
     (table.init 1 (i32.const 12) (i32.const 0) (i32.const 5))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -570,7 +570,7 @@
   (func (export "test")
     (table.init 1 (i32.const 12) (i32.const 2) (i32.const 3))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -594,7 +594,7 @@
   (func (export "test")
     (table.init $t0 1 (i32.const 28) (i32.const 1) (i32.const 3))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -642,7 +642,7 @@
   (func (export "test")
     (table.init $t0 1 (i32.const 12) (i32.const 5) (i32.const 0))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -690,7 +690,7 @@
   (func (export "test")
     (table.init $t0 1 (i32.const 31) (i32.const 2) (i32.const 0))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -738,7 +738,7 @@
   (func (export "test")
     (table.init $t0 1 (i32.const 31) (i32.const 5) (i32.const 0))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -762,7 +762,7 @@
   (func (export "test")
     (table.init $t1 1 (i32.const 26) (i32.const 1) (i32.const 3))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -810,7 +810,7 @@
   (func (export "test")
     (table.init $t1 1 (i32.const 12) (i32.const 5) (i32.const 0))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -858,7 +858,7 @@
   (func (export "test")
     (table.init $t1 1 (i32.const 29) (i32.const 2) (i32.const 0))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (module
   (table $t0 30 30 funcref)
@@ -906,7 +906,7 @@
   (func (export "test")
     (table.init $t1 1 (i32.const 29) (i32.const 5) (i32.const 0))
     ))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds table access")
 
 (assert_invalid
   (module
@@ -1503,7 +1503,7 @@
     (call_indirect (type 0) (local.get $n)))
   (func (export "run") (param $offs i32) (param $len i32)
     (table.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
-(assert_trap (invoke "run" (i32.const 24) (i32.const 16)) "out of bounds")
+(assert_trap (invoke "run" (i32.const 24) (i32.const 16)) "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -1565,7 +1565,7 @@
     (call_indirect (type 0) (local.get $n)))
   (func (export "run") (param $offs i32) (param $len i32)
     (table.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
-(assert_trap (invoke "run" (i32.const 25) (i32.const 16)) "out of bounds")
+(assert_trap (invoke "run" (i32.const 25) (i32.const 16)) "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -1627,7 +1627,7 @@
     (call_indirect (type 0) (local.get $n)))
   (func (export "run") (param $offs i32) (param $len i32)
     (table.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
-(assert_trap (invoke "run" (i32.const 96) (i32.const 32)) "out of bounds")
+(assert_trap (invoke "run" (i32.const 96) (i32.const 32)) "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -1817,7 +1817,7 @@
     (call_indirect (type 0) (local.get $n)))
   (func (export "run") (param $offs i32) (param $len i32)
     (table.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
-(assert_trap (invoke "run" (i32.const 97) (i32.const 31)) "out of bounds")
+(assert_trap (invoke "run" (i32.const 97) (i32.const 31)) "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2007,7 +2007,7 @@
     (call_indirect (type 0) (local.get $n)))
   (func (export "run") (param $offs i32) (param $len i32)
     (table.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
-(assert_trap (invoke "run" (i32.const 48) (i32.const 4294967280)) "out of bounds")
+(assert_trap (invoke "run" (i32.const 48) (i32.const 4294967280)) "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")
@@ -2101,7 +2101,7 @@
     (call_indirect (type 0) (local.get $n)))
   (func (export "run") (param $offs i32) (param $len i32)
     (table.init 0 (local.get $offs) (i32.const 8) (local.get $len))))
-(assert_trap (invoke "run" (i32.const 0) (i32.const 4294967292)) "out of bounds")
+(assert_trap (invoke "run" (i32.const 0) (i32.const 4294967292)) "out of bounds table access")
 (assert_trap (invoke "test" (i32.const 0)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 1)) "uninitialized element")
 (assert_trap (invoke "test" (i32.const 2)) "uninitialized element")

--- a/test/core/table_set.wast
+++ b/test/core/table_set.wast
@@ -38,15 +38,15 @@
 (assert_return (invoke "set-funcref" (i32.const 0) (ref.null func)))
 (assert_return (invoke "get-funcref" (i32.const 0)) (ref.null func))
 
-(assert_trap (invoke "set-externref" (i32.const 2) (ref.null extern)) "out of bounds")
-(assert_trap (invoke "set-funcref" (i32.const 3) (ref.null func)) "out of bounds")
-(assert_trap (invoke "set-externref" (i32.const -1) (ref.null extern)) "out of bounds")
-(assert_trap (invoke "set-funcref" (i32.const -1) (ref.null func)) "out of bounds")
+(assert_trap (invoke "set-externref" (i32.const 2) (ref.null extern)) "out of bounds table access")
+(assert_trap (invoke "set-funcref" (i32.const 3) (ref.null func)) "out of bounds table access")
+(assert_trap (invoke "set-externref" (i32.const -1) (ref.null extern)) "out of bounds table access")
+(assert_trap (invoke "set-funcref" (i32.const -1) (ref.null func)) "out of bounds table access")
 
-(assert_trap (invoke "set-externref" (i32.const 2) (ref.extern 0)) "out of bounds")
-(assert_trap (invoke "set-funcref-from" (i32.const 3) (i32.const 1)) "out of bounds")
-(assert_trap (invoke "set-externref" (i32.const -1) (ref.extern 0)) "out of bounds")
-(assert_trap (invoke "set-funcref-from" (i32.const -1) (i32.const 1)) "out of bounds")
+(assert_trap (invoke "set-externref" (i32.const 2) (ref.extern 0)) "out of bounds table access")
+(assert_trap (invoke "set-funcref-from" (i32.const 3) (i32.const 1)) "out of bounds table access")
+(assert_trap (invoke "set-externref" (i32.const -1) (ref.extern 0)) "out of bounds table access")
+(assert_trap (invoke "set-funcref-from" (i32.const -1) (i32.const 1)) "out of bounds table access")
 
 
 ;; Type errors


### PR DESCRIPTION
This PR fixes some failure strings in the spec tests:
1. Fixed `out of bound` to `out of bounds memory access` or `out of bounds table access`.
2. Fixed `uninitialized` to `uninitialized element`.
3. Fixed `undefined` to `undefined element`.
4. Fixed `indirect call` to `indirect call type mismatch`.