### PR TITLE
Fix some js-api bugs.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -740,14 +740,9 @@ interface Table {
 };
 </pre>
 
-<div>
-A {{Table}} object represents a single [=table instance=]
-which can be simultaneously referenced by multiple {{Instance}} objects.
-Each {{Table}} object has the following internal slots:
-
-    * \[[Table]] : a [=table address=]
-    * \[[Values]] : a [=list=] whose elements depend on the element type of \[[Table]]'s [=table type=].
-</div>
+A {{Table}} object represents a single [=table instance=] which can be simultaneously referenced by
+multiple {{Instance}} objects.
+Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address=].
 
 <div algorithm>
     To <dfn>initialize a table object</dfn> |table| from a [=table address=] |tableaddr|, perform the following steps:
@@ -770,7 +765,7 @@ Each {{Table}} object has the following internal slots:
 <div algorithm>
     The <dfn constructor for="Table">Table(|descriptor|, |value|)</dfn> constructor, when invoked, performs the following steps:
     1. Let |elementType| be [=ToValueType=](|descriptor|["element"]).
-    1. let |initial| be |descriptor|["initial"].
+    1. Let |initial| be |descriptor|["initial"].
     1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
     1. If |maximum| is not empty and |maximum| &lt; |initial|, throw a {{RangeError}} exception.
     1. If |value| is missing,
@@ -782,8 +777,6 @@ Each {{Table}} object has the following internal slots:
     1. Let (|store|, |tableaddr|) be [=table_alloc=](|store|, |type|, |ref|). <!-- TODO(littledan): Report allocation failure https://github.com/WebAssembly/spec/issues/584 -->
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
     1. [=initialize a table object|Initialize=] **this** from |tableaddr|.
-    1. [=list/Empty=] **this**.\[[Values]].
-    1. [=list/Append=] |value| to **this**.\[[Values]] |initial| times.
 </div>
 
 <div algorithm=dom-Table-grow>
@@ -802,7 +795,6 @@ Each {{Table}} object has the following internal slots:
         Note: The above exception can happen due to either insufficient memory or an invalid size parameter.
 
     1. Set the [=surrounding agent=]'s [=associated store=] to |result|.
-    1. [=list/Append=] |value| to **this**.\[[Values]] |delta| times.
     1. Return |initialSize|.
 </div>
 
@@ -819,14 +811,12 @@ Each {{Table}} object has the following internal slots:
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let |result| be [=table_read=](|store|, |tableaddr|, |index|).
     1. If |result| is [=error=], throw a {{RangeError}} exception.
-    1. Let |function| be the result of creating [=a new Exported Function=] from |result|.
-    1. Return |function|.
+    1. Return [=ToJSValue=](|result|).
 </div>
 
 <div algorithm>
     The <dfn method for="Table">set(|index|, |value|)</dfn> method, when invoked, performs the following steps:
     1. Let |tableaddr| be **this**.\[[Table]].
-    1. Let |values| be **this**.\[[Values]].
     1. Let (<var ignore>limits</var>, |elementType|) be [=table_type=](|tableaddr|).
     1. If |value| is missing,
         1. Let |ref| be [=DefaultValue=](|elementType|).
@@ -897,7 +887,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. If |s| equals "i64", return [=i64=].
     1. If |s| equals "f32", return [=f32=].
     1. If |s| equals "f64", return [=f64=].
-    1. If |s| equals "funcref", return [=funcref=].
+    1. If |s| equals "anyfunc", return [=funcref=].
     1. If |s| equals "externref", return [=externref=].
     1. Assert: This step is not reached.
 </div>
@@ -908,6 +898,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. If |valuetype| equals [=i64=], return [=i64.const=] 0.
     1. If |valuetype| equals [=f32=], return [=f32.const=] 0.
     1. If |valuetype| equals [=f64=], return [=f64.const=] 0.
+    1. If |valuetype| equals [=funcref=], return [=ref.null=] [=funcref=].
     1. If |valuetype| equals [=externref=], return [=ToWebAssemblyValue=](undefined, |valuetype|).
     1. Assert: This step is not reached.
 </div>
@@ -917,7 +908,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |mutable| be |descriptor|["mutable"].
     1. Let |valuetype| be [=ToValueType=](|descriptor|["value"]).
     1. If |v| is missing,
-        1. let |value| be [=DefaultValue=](|valuetype|).
+        1. Let |value| be [=DefaultValue=](|valuetype|).
     1. Otherwise,
         1. Let |value| be [=ToWebAssemblyValue=](|v|, |valuetype|).
     1. If |mutable| is true, let |globaltype| be [=var=] |valuetype|; otherwise, let |globaltype| be [=const=] |valuetype|.
@@ -1088,10 +1079,13 @@ Note: Number values which are equal to NaN may have various observable NaN paylo
 </div>
 
 <div algorithm>
-    For <dfn>retrieving an extern value</dfn> from a [=extern address=] |externaddr|, perform the following steps:
-    1. Let |map| be the [=surrounding agent=]'s associated [=extern value cache=].
-    1. Assert: |map|[|externaddr|] [=map/exists=].
-    1. Return |map|[|externaddr|].
+
+For <dfn>retrieving an extern value</dfn> from a [=extern address=] |externaddr|, perform the following steps:
+
+1. Let |map| be the [=surrounding agent=]'s associated [=extern value cache=].
+1. Assert: |map|[|externaddr|] [=map/exists=].
+1. Return |map|[|externaddr|].
+
 </div>
 
 <div algorithm>
@@ -1128,7 +1122,6 @@ The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript va
 1. Assert: This step is not reached.
 
 </div>
-
 
 <h3 id="error-objects">Error Objects</h3>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1080,7 +1080,7 @@ Note: Number values which are equal to NaN may have various observable NaN paylo
 
 <div algorithm>
 
-For <dfn>retrieving an extern value</dfn> from a [=extern address=] |externaddr|, perform the following steps:
+For <dfn>retrieving an extern value</dfn> from an [=extern address=] |externaddr|, perform the following steps:
 
 1. Let |map| be the [=surrounding agent=]'s associated [=extern value cache=].
 1. Assert: |map|[|externaddr|] [=map/exists=].


### PR DESCRIPTION
* table.[[Values]] was removed upstream but accidentally kept in a merge.
* table.get() was not updated to support non-funcref tables.
* DefaultValue() omitted funcref.
* Various typos were fixed.